### PR TITLE
Address PyYAML CVE vulnerability

### DIFF
--- a/map-engraver/map/layer/layer.py
+++ b/map-engraver/map/layer/layer.py
@@ -24,7 +24,7 @@ class Layer(ILayer):
     @staticmethod
     def create_from_yaml(file_path: str, parent: Union[IMap, 'Layer']):
         file = open(file_path, 'r')
-        config = yaml.load(file)
+        config = yaml.safe_load(file)
         directory = os.path.dirname(file_path)
         return Layer().set_config(config)\
             .set_relative_directory(directory)\

--- a/map-engraver/map/map_config.py
+++ b/map-engraver/map/map_config.py
@@ -13,7 +13,7 @@ class MapConfig:
     @staticmethod
     def create_from_yaml(file_path: str) -> 'MapConfig':
         file = open(file_path, 'r')
-        config = yaml.load(file)
+        config = yaml.safe_load(file)
         map_config = MapConfig(config)
         file_dir = os.path.dirname(file_path)
         map_config.set_relative_directory(file_dir)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 CairoSVG==2.1.1
-PyYAML==3.12
+PyYAML==5.1
 Shapely==1.7a1
 cairocffi==0.8.0
 pyproj==1.9.5.1


### PR DESCRIPTION
Addresses PyYAML vulnerability outlined here:

https://nvd.nist.gov/vuln/detail/CVE-2017-18342

More information from the developers of PyYAML here:

https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation

## Changes

* Upgraded PyYAML to 5.1
* Switched from `yaml.load()` to `yaml.safe_load()`. This doesn't seem to affect anything.