### PR TITLE
Support for dictionaries for SymbolDrawer

### DIFF
--- a/map_engraver/drawable/geometry/symbol_drawer.py
+++ b/map_engraver/drawable/geometry/symbol_drawer.py
@@ -1,5 +1,5 @@
 import abc
-from typing import List, Union
+from typing import List, Union, Dict, Iterable, TypeVar, Tuple
 
 from shapely.geometry import Point
 
@@ -7,34 +7,42 @@ from map_engraver.canvas import Canvas
 from map_engraver.drawable.drawable import Drawable
 from functools import cmp_to_key
 
+T = TypeVar('T')
+
 
 class SymbolDrawer(Drawable, abc.ABC):
-    points: List[Union[Point]]
+    points: Union[Dict[T, Point], Iterable[Point]]
 
     def __init__(self):
         self.points = []
         self.z_sort_func = SymbolDrawer.default_z_sort_func
 
     def draw(self, canvas: Canvas):
-        self.points = self.z_sort_func(self.points)
-        for point in self.points:
-            self.draw_symbol(point, canvas)
+        dict_points: Dict[T, Point]
+        if not isinstance(self.points, dict):
+            dict_points = dict((i, j) for i, j in enumerate(self.points))
+        else:
+            dict_points = self.points
+
+        points = self.z_sort_func(dict_points)
+        for key, point in points:
+            self.draw_symbol(key, point, canvas)
 
     @abc.abstractmethod
-    def draw_symbol(self, point: Point, canvas: Canvas):
+    def draw_symbol(self, idx: T, point: Point, canvas: Canvas):
         pass
 
     @staticmethod
-    def default_z_sort_func(points: List[Point]) -> List[Point]:
+    def default_z_sort_func(points: Dict[T, Point]) -> List[Tuple[T, Point]]:
         """
         Sorts the rendering of symbols on the canvas based on how far down the
         canvas the point will appear.
         """
-        def func(a: Point, b: Point) -> int:
-            if a.y < b.y:
+        def func(a: Tuple[T, Point], b: Tuple[T, Point]) -> int:
+            if a[1].y < b[1].y:
                 return -1
-            if a.y > b.y:
+            if a[1].y > b[1].y:
                 return 1
-            return int(a.x - b.x)
+            return int(a[1].x - b[1].x)
 
-        return sorted(points, key=cmp_to_key(func))
+        return sorted(points.items(), key=cmp_to_key(func))

--- a/tests/drawable/geometry/test_symbol_drawer.py
+++ b/tests/drawable/geometry/test_symbol_drawer.py
@@ -26,7 +26,7 @@ class TestPolygonDrawer(unittest.TestCase):
         canvas = canvas_builder.build()
 
         class MySymbolDrawer(SymbolDrawer):
-            def draw_symbol(self, point: Point, canvas: Canvas):
+            def draw_symbol(self, key, point: Point, canvas: Canvas):
                 canvas.context.set_source_rgba(point.x/100, point.y/100, 0, 1)
                 CairoHelper.draw_point(
                     canvas.context,
@@ -58,3 +58,47 @@ class TestPolygonDrawer(unittest.TestCase):
             assert data.find('rgb(50%,30%,0%)') != -1
             assert data.find('rgb(50%,30%,0%)') < data.find('rgb(45%,40%,0%)')
             assert data.find('rgb(45%,40%,0%)') < data.find('rgb(55%,40%,0%)')
+
+    def test_can_iterate_dict(self):
+        path = Path(__file__).parent.joinpath(
+            'output/symbol_drawer_can_iterate_dict.svg'
+        )
+        path.unlink(missing_ok=True)
+        canvas_builder = CanvasBuilder()
+        canvas_builder.set_path(path)
+        canvas_builder.set_size(Cu.from_pt(100), Cu.from_pt(100))
+
+        canvas = canvas_builder.build()
+
+        class MySymbolDrawer(SymbolDrawer):
+            def draw_symbol(self, key, point: Point, canvas: Canvas):
+                canvas.context.set_source_rgba(point.x/100, point.y/100, 0, 1)
+                CairoHelper.draw_point(
+                    canvas.context,
+                    point,
+                    Cu.from_pt(key).pt
+                )
+
+        my_symbol_drawer = MySymbolDrawer()
+        my_symbol_drawer.points = {
+            2: Point(30, 70),
+            4: Point(35, 60),
+            6: Point(40, 50),
+            8: Point(45, 40),
+            10: Point(50, 30),
+            12: Point(55, 40),
+            14: Point(60, 50),
+            16: Point(65, 60),
+            18: Point(70, 70)
+        }
+        my_symbol_drawer.draw(canvas)
+
+        canvas.close()
+
+        assert path.exists()
+
+        with open(path, 'r') as file:
+            data = file.read()
+            # Assert that the symbols appear with correct size
+            assert data.find('d="M 55 30 C') != -1
+            assert data.find('d="M 79 70 C') != -1


### PR DESCRIPTION
Now that `OsmPoint`s have been removed in favour of just `Point`, we no longer have `osm_tags` when rendering symbols.

This PR allows us to pass in a dictionary of objects in the symbol drawer. The key can be used as a reference for which symbol to draw.