### PR TITLE
Homogenize geo_canvas_mask return types to always be MultiPolygons

### DIFF
--- a/map_engraver/data/geo_canvas_ops/geo_canvas_mask.py
+++ b/map_engraver/data/geo_canvas_ops/geo_canvas_mask.py
@@ -45,7 +45,7 @@ def canvas_mask(
     transformers_builder.set_data_crs(None)
     crs_to_canvas = transformers_builder.build_crs_to_canvas_transformer()
     crs_polygon = transform(crs_to_canvas, crs_polygon)
-    return canvas_polygon.intersection(crs_polygon)
+    return geoms_to_multi_polygon(canvas_polygon.intersection(crs_polygon))
 
 
 def canvas_crs_mask(
@@ -70,7 +70,7 @@ def canvas_crs_mask(
     if crs_polygon is None:
         return MultiPolygon([canvas_polygon])
 
-    return canvas_polygon.intersection(crs_polygon)
+    return geoms_to_multi_polygon(canvas_polygon.intersection(crs_polygon))
 
 
 def canvas_wgs84_mask(


### PR DESCRIPTION
Currently `canvas_mask` and `canvas_crs_mask` can return `MultiPolygon` and `Polygon` types depending on the generated mask. To make operations easier on the objects, this PR makes sure the return type is always `MultiPolygon`