### PR TITLE
Add rotation parameters to canvas transformer

### DIFF
--- a/map_engraver/data/geo_canvas_ops/geo_canvas_transformers_builder.py
+++ b/map_engraver/data/geo_canvas_ops/geo_canvas_transformers_builder.py
@@ -17,6 +17,7 @@ from map_engraver.data.geo_canvas_ops.geo_canvas_transformers import \
 
 class GeoCanvasTransformersBuilder:
     crs: Optional[pyproj.CRS]
+    rotation: float
     scale: Optional[GeoCanvasScale]
     origin_for_geo: Optional[GeoCoordinate]
     origin_for_canvas: Optional[CanvasCoordinate]
@@ -26,6 +27,7 @@ class GeoCanvasTransformersBuilder:
 
     def __init__(self):
         self.crs = None
+        self.rotation = 0
         self.scale = None
         self.origin_for_geo = None
         self.origin_for_canvas = None
@@ -35,6 +37,9 @@ class GeoCanvasTransformersBuilder:
 
     def set_crs(self, crs: Optional[pyproj.CRS]):
         self.crs = crs
+
+    def set_rotation(self, rotation: float):
+        self.rotation = rotation
 
     def set_scale(self, scale: Optional[GeoCanvasScale]):
         self.scale = scale
@@ -112,6 +117,7 @@ class GeoCanvasTransformersBuilder:
         builder.set_data_crs(self.data_crs)
         builder.set_is_crs_yx(self.is_crs_yx)
         builder.set_is_data_yx(self.is_data_yx)
+        builder.set_rotation(self.rotation)
         return builder
 
     def build_crs_to_canvas_transformer(self):
@@ -130,6 +136,7 @@ class GeoCanvasTransformersBuilder:
             self.origin_for_geo,
             self.origin_for_canvas,
             self.data_crs,
+            rotation=self.rotation,
             is_crs_yx=self.is_crs_yx,
             is_data_yx=self.is_data_yx
         )
@@ -150,6 +157,7 @@ class GeoCanvasTransformersBuilder:
             self.origin_for_geo,
             self.origin_for_canvas,
             self.data_crs,
+            rotation=self.rotation,
             is_crs_yx=self.is_crs_yx,
             is_data_yx=self.is_data_yx
         )

--- a/tests/data/geo_canvas_ops/test_geo_canvas_transformers_builder.py
+++ b/tests/data/geo_canvas_ops/test_geo_canvas_transformers_builder.py
@@ -104,6 +104,7 @@ class TestGeoCanvasTransformersBuilder(unittest.TestCase):
 
         builder = GeoCanvasTransformersBuilder()
         builder.set_crs(british_crs)
+        builder.set_rotation(0.1)
         builder.set_data_crs(wgs84_crs)
         builder.set_origin_for_geo(GeoCoordinate(325600, 673400, british_crs))
         builder.set_origin_for_canvas(CanvasCoordinate.from_pt(200, 200))
@@ -123,12 +124,14 @@ class TestGeoCanvasTransformersBuilder(unittest.TestCase):
         )
         self.assertEqual(builder.scale, builder_copy.scale)
 
+        builder_copy.set_rotation(0.2)
         builder_copy.set_crs(wgs84_crs)
         builder_copy.set_data_crs(british_crs)
         builder_copy.set_origin_for_geo(GeoCoordinate(0, 0, british_crs))
         builder_copy.set_origin_for_canvas(CanvasCoordinate.from_pt(100, 100))
         builder_copy.set_scale(GeoCanvasScale(100, CanvasUnit.from_pt(200)))
 
+        self.assertNotEqual(builder.rotation, builder_copy.rotation)
         self.assertNotEqual(builder.crs, builder_copy.crs)
         self.assertNotEqual(builder.data_crs, builder_copy.data_crs)
         self.assertNotEqual(


### PR DESCRIPTION
While the `geo_canvas_transformers` support passing in a rotation, the `geo_canvas_transformer_builder` does not. This PR adds support for setting the `rotation`.