### PR TITLE
Removed transformer function from OsmToShapely

### DIFF
--- a/map_engraver/data/osm_shapely/osm_to_shapely.py
+++ b/map_engraver/data/osm_shapely/osm_to_shapely.py
@@ -12,26 +12,12 @@ from map_engraver.data.osm.util import get_nodes_for_way
 class OsmToShapely:
     def __init__(
             self,
-            osm: Osm,
-            transform: Optional[Callable[
-                [float, float],
-                Tuple[float, float]
-            ]] = None
+            osm: Osm
     ):
         """
         :param osm:
-        :param transform: In rare situations it might be useful to transform
-                          the coordinate data to a different projection when
-                          creating the shapely objects. By default, coordinates
-                          are transformed to the WGS 84 projection (lat, lon),
-                          but this optional parameter can be used to pass in
-                          a custom transformer.
         """
         self.osm = osm
-        if transform is None:
-            self.transform = lambda x, y: (x, y)
-        else:
-            self.transform = transform
         self._incomplete_refs_handler = lambda element, refs: None
 
     @property
@@ -49,7 +35,7 @@ class OsmToShapely:
             self,
             node: Node
     ) -> Optional[Point]:
-        return Point(*self.transform(node.lat, node.lon))
+        return Point(node.lat, node.lon)
 
     def nodes_to_points(
             self,
@@ -64,7 +50,7 @@ class OsmToShapely:
         nodes = get_nodes_for_way(self.osm, way.id)
         line_string_array = []
         for node in nodes:
-            line_string_array.append(self.transform(node.lat, node.lon))
+            line_string_array.append((node.lat, node.lon))
         return LineString(line_string_array)
 
     def ways_to_line_strings(
@@ -80,7 +66,7 @@ class OsmToShapely:
         nodes = get_nodes_for_way(self.osm, way.id)
         polygon_array = []
         for node in nodes:
-            polygon_array.append(self.transform(node.lat, node.lon))
+            polygon_array.append((node.lat, node.lon))
         if polygon_array[len(polygon_array)-1] == polygon_array[0] and \
                 len(polygon_array) > 2:
             p = Polygon(polygon_array)
@@ -234,7 +220,7 @@ class OsmToShapely:
         for outer_way_nodes in outer_ways_nodes:
             exterior_nodes = []
             for node in outer_way_nodes:
-                exterior_nodes.append(self.transform(node.lat, node.lon))
+                exterior_nodes.append((node.lat, node.lon))
             exterior_polygon = Polygon(exterior_nodes)
             if exterior_polygon.exterior.is_ccw:
                 exterior_polygon = Polygon(reversed(exterior_nodes))
@@ -259,7 +245,7 @@ class OsmToShapely:
         for inner_way_nodes in inner_ways_nodes:
             interior_coordinates = []
             for node in inner_way_nodes:
-                interior_coordinates.append(self.transform(node.lat, node.lon))
+                interior_coordinates.append((node.lat, node.lon))
             interior_polygon = Polygon(interior_coordinates)
             if not interior_polygon.exterior.is_ccw:
                 interior_coordinates = list(reversed(interior_coordinates))

--- a/tests/data/osm_shapely/test_osm_to_shapely.py
+++ b/tests/data/osm_shapely/test_osm_to_shapely.py
@@ -206,20 +206,6 @@ class TestOsmToShapely(unittest.TestCase):
         with self.assertRaises(WayToPolygonError):
             osm_to_shapely.way_to_polygon(highway_service_way)
 
-    def test_transform(self):
-        path = Path(__file__).parent.joinpath('data.osm')
-
-        osm_map = Parser.parse(path)
-        osm_to_shapely = OsmToShapely(osm_map, lambda x, y: (0, 0))
-
-        highway_service_way = osm_map.get_way('-101873')
-        highway_service_line_string = osm_to_shapely.way_to_line_string(
-            highway_service_way
-        )
-        assert list(highway_service_line_string.coords) == [
-            (0, 0), (0, 0), (0, 0)
-        ]
-
     def test_incomplete_refs_handler(self):
         path = Path(__file__).parent.joinpath('incomplete_data.osm')
 


### PR DESCRIPTION
To elaborate why it's not useful, generally when you want to transform the coordinates, it's to reproject the geometry to a new projection system. Before reprojection you should apply a mask to avoid out-of-bounds coordinates from being projected. OsmToShapely's transformer function may help in some situations, but most of the time it is not.