### PR TITLE
Remove unnecessary class properties for OSM elements + Add type hinting

### DIFF
--- a/map_engraver/data/osm/node.py
+++ b/map_engraver/data/osm/node.py
@@ -10,5 +10,3 @@ class Node(Element):
         super().__init__(osm_element)
         self.lat = float(osm_element.attrib['lat'])
         self.lon = float(osm_element.attrib['lon'])
-        self.member_of_ways = []
-        self.member_of_relations = []

--- a/map_engraver/data/osm/relation.py
+++ b/map_engraver/data/osm/relation.py
@@ -10,7 +10,6 @@ class Relation(Element):
     def __init__(self, osm_element):
         super().__init__(osm_element)
         self.members = Relation._get_relation_members(osm_element)
-        self.nodes = []
         self.relations = []
         self.neighboring_ways = []
         self.neighboring_relations = []

--- a/map_engraver/data/osm/util.py
+++ b/map_engraver/data/osm/util.py
@@ -1,5 +1,7 @@
-from map_engraver.data.osm import Osm
+from typing import List
+
+from map_engraver.data.osm import Osm, Node
 
 
-def get_nodes_for_way(osm: Osm, way_ref: str):
+def get_nodes_for_way(osm: Osm, way_ref: str) -> List[Node]:
     return [osm.nodes[node_ref] for node_ref in osm.ways[way_ref].node_refs]

--- a/map_engraver/data/osm/way.py
+++ b/map_engraver/data/osm/way.py
@@ -11,7 +11,6 @@ class Way(Element):
     def __init__(self, osm_element):
         super().__init__(osm_element)
         self.node_refs = Way._get_way_node_refs(osm_element)
-        self.nodes = None
 
     @staticmethod
     def _get_way_node_refs(osm_element: ElementTree) -> List[str]:


### PR DESCRIPTION
Some unnecessary properties for OSM elements `node`, `way`, and `relation` were copied from the original project. These were originally intended to help with caching, but this hasn't been implemented yet, and probably never will be. This PR removes them.

The function `get_nodes_for_way` has also been given type hinting.