### PR TITLE
Add function to extract natural=coastline from OSM files

### DIFF
--- a/map_engraver/data/osm_shapely/natural_coastline.py
+++ b/map_engraver/data/osm_shapely/natural_coastline.py
@@ -1,0 +1,116 @@
+from enum import Enum
+from typing import Tuple
+
+from shapely.geometry import MultiPolygon, Polygon, LinearRing, LineString
+from shapely.ops import cascaded_union
+
+from map_engraver.data.osm import Osm
+from map_engraver.data.osm.filter import filter_elements
+from map_engraver.data.osm.util import get_nodes_for_way
+from map_engraver.data.osm_shapely.piece_together_ways import piece_together_ways
+from map_engraver.data.osm_shapely_ops.homogenize import geoms_to_multi_line_string
+
+
+class CoastlineOutputType(Enum):
+    LAND = 1
+    WATER = 2
+
+
+def natural_coastline_to_multi_polygon(
+        osm: Osm,
+        bounds: Tuple[float, float, float, float],
+        output_type: CoastlineOutputType
+) -> MultiPolygon:
+    """
+    Returns a MultiPolygon that represents the land contained within the
+    coastline. Only ways that have the tag natural=coastline are included.
+
+    In OpenStreetMap, coastlines are built up by a sequence of way elements
+    that span whole continents, but are regularly split in between to avoid
+    editors from needing to download massive objects. They are similar to
+    multipolygon relation elements, in that they have an outer and inner role,
+    but instead the roles are expressed as way directions. For example, to draw
+    a landmass, the way's nodes should be ordered counter-clock-wise.
+
+    Warning: If no `natural=coastline` ways are found, an error will be raised.
+
+    :param osm: The parsed OSM file containing the coastline ways.
+    :param bounds: The size the polygon should be generated for.
+    :param output_type: Specify whether to return land or water polygons.
+    :return:
+    """
+    osm_coastline = filter_elements(
+        osm,
+        lambda _, way: (
+                'natural' in way.tags and
+                way.tags['natural'] == 'coastline'
+        ),
+        filter_nodes=False,
+        filter_relations=False
+    )
+
+    if len(osm_coastline.ways) == 0:
+        raise Exception('Failed to generate coastline. One or more OSM ways'
+                        'with the tag natural=coastline are required.')
+
+    bounds_polygon = Polygon([
+        (bounds[0], bounds[1]),
+        (bounds[0], bounds[3]),
+        (bounds[2], bounds[3]),
+        (bounds[2], bounds[1])
+    ])
+
+    way_refs = []
+    way_all_nodes = {}
+    way_start_nodes = {}
+    way_end_nodes = {}
+
+    for ref, way in osm_coastline.ways.items():
+        way_nodes = get_nodes_for_way(osm, ref)
+        way_all_nodes[ref] = way_nodes
+        way_start_nodes[ref] = way_nodes[0]
+        way_end_nodes[ref] = way_nodes[
+            len(way_all_nodes[ref]) - 1
+            ]
+        way_refs.append(ref)
+
+    incomplete_ways_nodes, complete_ways_nodes = piece_together_ways(
+        way_refs,
+        way_all_nodes,
+        way_start_nodes,
+        way_end_nodes,
+    )
+
+    # Convert all complete_way_nodes to Polygons. Clock-wise Todo
+    complete_cw_polygons = []
+    complete_ccw_polygons = []
+    for ref, complete_way_nodes in complete_ways_nodes.items():
+        coordinates = []
+        for way_node in complete_way_nodes:
+            coordinates.append((way_node.lat, way_node.lon))
+        linear_ring = LinearRing(coordinates)
+        if linear_ring.is_ccw:
+            complete_ccw_polygons.append(Polygon(coordinates))
+        else:
+            complete_cw_polygons.append(
+                bounds_polygon.difference(Polygon(coordinates))
+            )
+
+    incomplete_linear_strings = []
+    for ref, incomplete_way_nodes in incomplete_ways_nodes.items():
+        coordinates = []
+        for way_node in incomplete_way_nodes:
+            coordinates.append((way_node.lat, way_node.lon))
+        linear_string = LineString(coordinates)
+        incomplete_linear_strings.append(linear_string)
+
+    incomplete_multi_line_strings = cascaded_union(incomplete_linear_strings)
+    incomplete_multi_line_strings = geoms_to_multi_line_string(
+        incomplete_multi_line_strings.intersection(bounds_polygon)
+    )
+    complete_polygons = []
+    for incomplete_line_string in incomplete_multi_line_strings.geoms:
+        print(incomplete_line_string)
+
+    # Todo
+

--- a/map_engraver/data/osm_shapely/natural_coastline.py
+++ b/map_engraver/data/osm_shapely/natural_coastline.py
@@ -1,14 +1,22 @@
 from enum import Enum
 from typing import Tuple
 
-from shapely.geometry import MultiPolygon, Polygon, LinearRing, LineString
-from shapely.ops import cascaded_union
+from shapely.geometry import \
+    MultiPolygon,\
+    Polygon,\
+    LinearRing,\
+    LineString,\
+    GeometryCollection
+from shapely.ops import unary_union
 
 from map_engraver.data.osm import Osm
 from map_engraver.data.osm.filter import filter_elements
 from map_engraver.data.osm.util import get_nodes_for_way
-from map_engraver.data.osm_shapely.piece_together_ways import piece_together_ways
-from map_engraver.data.osm_shapely_ops.homogenize import geoms_to_multi_line_string
+from map_engraver.data.osm_shapely.piece_together_ways import \
+    piece_together_ways
+from map_engraver.data.osm_shapely_ops.homogenize import \
+    geoms_to_multi_line_string, \
+    geoms_to_multi_polygon
 
 
 class CoastlineOutputType(Enum):
@@ -36,8 +44,10 @@ def natural_coastline_to_multi_polygon(
 
     :param osm: The parsed OSM file containing the coastline ways.
     :param bounds: The size the polygon should be generated for.
-    :param output_type: Specify whether to return land or water polygons.
-    :return:
+                   Note that incomplete ways must begin and terminate outside
+                   the bounds for the algorithm to work.
+    :param output_type: Specify whether to return a land or water MultiPolygon.
+    :return: A MultiPolygon representing the coastline shape.
     """
     osm_coastline = filter_elements(
         osm,
@@ -81,21 +91,21 @@ def natural_coastline_to_multi_polygon(
         way_end_nodes,
     )
 
-    # Convert all complete_way_nodes to Polygons. Clock-wise Todo
-    complete_cw_polygons = []
-    complete_ccw_polygons = []
+    # Convert all complete_way_nodes to Polygons. Clockwise polygons are
+    # considered land, counter-clockwise polygons are water.
+    complete_land_polygons = []
+    complete_water_polygons = []
     for ref, complete_way_nodes in complete_ways_nodes.items():
         coordinates = []
         for way_node in complete_way_nodes:
             coordinates.append((way_node.lat, way_node.lon))
         linear_ring = LinearRing(coordinates)
         if linear_ring.is_ccw:
-            complete_ccw_polygons.append(Polygon(coordinates))
+            complete_water_polygons.append(Polygon(coordinates))
         else:
-            complete_cw_polygons.append(
-                bounds_polygon.difference(Polygon(coordinates))
-            )
+            complete_land_polygons.append(Polygon(coordinates))
 
+    # Convert all incomplete ways to MultiLineStrings.
     incomplete_linear_strings = []
     for ref, incomplete_way_nodes in incomplete_ways_nodes.items():
         coordinates = []
@@ -103,14 +113,212 @@ def natural_coastline_to_multi_polygon(
             coordinates.append((way_node.lat, way_node.lon))
         linear_string = LineString(coordinates)
         incomplete_linear_strings.append(linear_string)
-
-    incomplete_multi_line_strings = cascaded_union(incomplete_linear_strings)
+    incomplete_multi_line_strings = unary_union(incomplete_linear_strings)
     incomplete_multi_line_strings = geoms_to_multi_line_string(
         incomplete_multi_line_strings.intersection(bounds_polygon)
     )
-    complete_polygons = []
+
+    # Close all incomplete ways so they become Polygons.
+    incomplete_polygons = []
     for incomplete_line_string in incomplete_multi_line_strings.geoms:
-        print(incomplete_line_string)
+        # Todo:
+        # print('-------------------------')
+        # print(bounds)
+        # print(start_coordinate[0], start_coordinate[1])
+        # print(
+        #     start_coordinate[0] == bounds[0],
+        #     start_coordinate[1] == bounds[1]
+        # )
+        # print(
+        #     start_coordinate[0] == bounds[2],
+        #     start_coordinate[1] == bounds[3]
+        # )
+        # print(end_coordinate[0], end_coordinate[1])
+        # print(
+        #     end_coordinate[0] == bounds[0],
+        #     end_coordinate[1] == bounds[1]
+        # )
+        # print(
+        #     end_coordinate[0] == bounds[2],
+        #     end_coordinate[1] == bounds[3]
+        # )
 
-    # Todo
+        # We should now have a collection of incomplete ways that have start
+        # and end points that intersect the bounds. We now want to connect the
+        # end with the start to complete the shape so we can turn it into a
+        # Polygon. From the end coordinate, which should lie on the bound, we
+        # need to go counter-clockwise around the bounds until we reach the
+        # Start.
+        #
+        # In the example below, the LineString going through the bounds begins
+        # with 'S' and ends at 'E'. To complete the polygon, we loop through
+        # each section, in this case starting at Section 4, connecting between
+        # Section 1, and ending at Section 2, where the start point 'S'. The
+        # resulting lines are represented a solid line. In total, 2 points are
+        # added to the line_string to complete the shape.
+        #
+        #               Section 4
+        #              <──────────
+        #             ┌────────E ╴ ╴
+        #           │ │ ╭──────╯   ' ^
+        #           │ │ ╰──╮       ' │
+        # Section 1 │ │   ╭╯╭─╮    ' │ Section 3
+        #           │ │   ╰╮│ ╰╮   ' │
+        #           V │    ╰╯  │   ' │
+        #             └────────S ╴ '
+        #              ──────────>
+        #                Section 2
 
+        new_coordinates = list(incomplete_line_string.coords)
+        start_coordinate = new_coordinates[0]
+        end_coordinate = new_coordinates[-1]
+        sections_iterated = 0
+
+        while end_coordinate != start_coordinate:
+            # print(end_coordinate)  # Todo: remove when confident this works
+            if sections_iterated == 5:
+                # If this happens, we recommend either:
+                # 1. Downloading the rest of the coastline from OpenStreetMap
+                #    that are out of bounds.
+                # 2. Manually updating the OSM file to move the terminating
+                #    coordinate out of bounds.
+                # 3. Removing the coastline altogether.
+                raise Exception("""
+                Failed to generate coastline. An incomplete coastline way
+                starts with a point that is inside the bounds. Incomplete
+                coastlines must start and end with coordinates outside of the
+                bounds.
+                """)
+            # Section 1
+            if (
+                    end_coordinate[1] == bounds[1] and
+                    end_coordinate[0] != bounds[0]
+            ):
+                # print('section 1')  # Todo: remove when confident this works
+                if (
+                        start_coordinate[1] == end_coordinate[1] and
+                        start_coordinate[0] <= end_coordinate[0]
+                ):
+                    new_coordinate = start_coordinate
+                else:
+                    new_coordinate = (bounds[0], bounds[1])
+            # Section 2
+            elif (
+                    end_coordinate[0] == bounds[0] and
+                    end_coordinate[1] != bounds[3]
+            ):
+                # print('section 2')  # Todo: remove when confident this works
+                if (
+                        start_coordinate[0] == end_coordinate[0] and
+                        start_coordinate[1] >= end_coordinate[1]
+                ):
+                    new_coordinate = start_coordinate
+                else:
+                    new_coordinate = (bounds[0], bounds[3])
+            # Section 3
+            elif (
+                    end_coordinate[1] == bounds[3] and
+                    end_coordinate[0] != bounds[2]
+            ):
+                # print('section 3')  # Todo: remove when confident this works
+                if (
+                        start_coordinate[1] == end_coordinate[1] and
+                        start_coordinate[0] >= end_coordinate[0]
+                ):
+                    new_coordinate = start_coordinate
+                else:
+                    new_coordinate = (bounds[2], bounds[3])
+            # Section 4
+            elif (
+                    end_coordinate[0] == bounds[2] and
+                    end_coordinate[1] != bounds[1]
+            ):
+                # print('section 4')  # Todo: remove when confident this works
+                if (
+                        start_coordinate[0] == end_coordinate[0] and
+                        start_coordinate[1] <= end_coordinate[1]
+                ):
+                    new_coordinate = start_coordinate
+                else:
+                    new_coordinate = (bounds[2], bounds[1])
+            else:
+                # If this happens, we recommend either:
+                # 1. Downloading the rest of the coastline from OpenStreetMap
+                #    that are out of bounds.
+                # 2. Manually updating the OSM file to move the terminating
+                #    coordinate out of bounds.
+                # 3. Removing the coastline altogether.
+                raise Exception("""
+                Failed to generate coastline. An incomplete coastline way ends
+                with a point that is inside the bounds. Incomplete coastlines
+                must start and end with coordinates outside of the bounds.
+                """)
+
+            new_coordinates.append(new_coordinate)
+            end_coordinate = new_coordinate
+            sections_iterated += 1
+        incomplete_polygons.append(Polygon(new_coordinates))
+
+    # Start with the assumption that land will always be returned.
+    composite_geom = GeometryCollection()
+
+    # In theory, because the coastlines never overlap, it's possible to
+    # determine using the incomplete polygons whether land should or should not
+    # exist.
+    # If two polygons intersect, that means the land is the intersection of the
+    # two geoms. If they don't intersect, that means they are separate bodies
+    # of land, and can therefore be merged.
+    for incomplete_polygon in incomplete_polygons:
+        if composite_geom.intersects(incomplete_polygon):
+            composite_geom = composite_geom.intersection(
+                incomplete_polygon
+            )
+        else:
+            composite_geom = unary_union(
+                [composite_geom, incomplete_polygon]
+            )
+
+    # Add the complete land shapes.
+    if len(complete_land_polygons) > 0:
+        culled_land_polygons = unary_union(complete_land_polygons)\
+            .intersection(bounds_polygon)
+        composite_geom = unary_union([composite_geom, culled_land_polygons])
+
+    # Fun edge case, if there are no incomplete coastlines and no land
+    # polygons, but we have water polygons, we can assume that the bounds are
+    # within land.
+    if composite_geom.is_empty and len(complete_water_polygons) > 0:
+        composite_geom = bounds_polygon
+
+    # Subtract the complete water shapes.
+    if len(complete_water_polygons) > 0:
+        composite_geom = composite_geom.difference(unary_union(
+            complete_water_polygons
+        ))
+
+    # To return the water instead of land, we simply perform a symmetric
+    # difference of the land geom with the bounds polygon.
+    if output_type == CoastlineOutputType.WATER:
+        composite_geom = composite_geom.symmetric_difference(bounds_polygon)
+
+    composite_multi_polygon = geoms_to_multi_polygon(composite_geom)
+
+    # Todo: remove when confident this works
+    # This is helpful for debugging the output.
+    # Regex: (\d+) ([\d.]+) ([\d.]+)
+    # geom_id = 0
+    # for composite_polygon in composite_multi_polygon.geoms:
+    #     geom_id += 1
+    #     for composite_coord in composite_polygon.exterior.coords:
+    #         print(geom_id, composite_coord[0], composite_coord[1])
+    #     interior_geom_id = 1000 * geom_id
+    #     for composite_interior in composite_polygon.interiors:
+    #         interior_geom_id += 1
+    #         for composite_interior_coord in composite_interior.coords:
+    #             print(
+    #                 interior_geom_id,
+    #                 composite_interior_coord[0],
+    #                 composite_interior_coord[1]
+    #             )
+
+    return composite_multi_polygon

--- a/map_engraver/data/osm_shapely/osm_to_shapely.py
+++ b/map_engraver/data/osm_shapely/osm_to_shapely.py
@@ -7,7 +7,8 @@ from map_engraver.data.osm import Relation
 from map_engraver.data.osm import MemberTypes
 from map_engraver.data.osm import Osm
 from map_engraver.data.osm.util import get_nodes_for_way
-from map_engraver.data.osm_shapely.piece_together_ways import piece_together_ways
+from map_engraver.data.osm_shapely.piece_together_ways import \
+    piece_together_ways
 
 
 class OsmToShapely:

--- a/map_engraver/data/osm_shapely/osm_to_shapely.py
+++ b/map_engraver/data/osm_shapely/osm_to_shapely.py
@@ -1,5 +1,5 @@
 from shapely.geometry import Polygon, Point, LineString, MultiPolygon
-from typing import Optional, List, Tuple, Dict, Callable, Union
+from typing import Optional, List, Dict, Callable, Union
 
 from map_engraver.data.osm import Node
 from map_engraver.data.osm import Way
@@ -7,6 +7,7 @@ from map_engraver.data.osm import Relation
 from map_engraver.data.osm import MemberTypes
 from map_engraver.data.osm import Osm
 from map_engraver.data.osm.util import get_nodes_for_way
+from map_engraver.data.osm_shapely.piece_together_ways import piece_together_ways
 
 
 class OsmToShapely:
@@ -81,86 +82,6 @@ class OsmToShapely:
     ) -> Dict[str, Optional[Polygon]]:
         return {k: self.way_to_polygon(v) for k, v in ways.items()}
 
-    def _piece_together_ways(
-            self,
-            way_refs: List[str],
-            way_nodes: Dict[str, List[Node]],
-            way_start_nodes: Dict[str, Node],
-            way_end_nodes: Dict[str, Node]
-    ) -> Tuple[List[str], List[List[Node]]]:
-
-        output_ways = []
-        way_ref_index_1 = 0
-        while way_ref_index_1 < len(way_refs):
-            # print("----")
-            way_ref_1 = way_refs[way_ref_index_1]
-            # print("ref1 " + str(way_ref_1))
-
-            # way is closed, so delete this way from the list of ways to
-            # process and continue to the next way
-            if way_end_nodes[way_ref_1] == way_start_nodes[way_ref_1]:
-                # print(
-                # "Closed way!",
-                # way_end_nodes[way_ref_1],
-                # way_start_nodes[way_ref_1]
-                # )
-                output_ways.append(way_nodes[way_ref_1])
-
-                del way_refs[way_ref_index_1]
-                del way_nodes[way_ref_1]
-                del way_start_nodes[way_ref_1]
-                del way_end_nodes[way_ref_1]
-                continue
-
-            # go through all other ways (excluding self)
-            way_ref_index_2 = 0
-            while way_ref_index_2 < len(way_refs):
-                way_ref_2 = way_refs[way_ref_index_2]
-                if way_ref_1 == way_ref_2:
-                    way_ref_index_2 += 1
-                    continue
-
-                # print("ref2 " + str(way_ref_2))
-
-                # if the end node of the current way is connected to the start
-                # node of the other way
-                if way_end_nodes[way_ref_1] == way_start_nodes[way_ref_2]:
-                    # remove the first node of the other way to ensure we don't
-                    # have redundant nodes and add it to the end of the current
-                    # way
-                    way_nodes_2 = way_nodes[way_ref_2][1:]
-                    way_nodes[way_ref_1].extend(way_nodes_2)
-
-                    # updated the linked list attributes
-                    way_end_nodes[way_ref_1] = way_end_nodes[way_ref_2]
-
-                    # Delete any mention of this way entirely!
-                    del way_nodes[way_ref_2]
-                    del way_start_nodes[way_ref_2]
-                    del way_end_nodes[way_ref_2]
-                    del way_refs[way_ref_index_2]
-                    # if the index of the other way is behind the current way
-                    # index, make sure to change the index because the other
-                    # way was removed from the list!
-                    way_ref_index_2 -= 1
-                    if way_ref_index_1 > way_ref_index_2:
-                        way_ref_index_1 -= 1
-
-                    # Break out of this loop. The current way should be
-                    # reprocessed in an attempt to discover more ways to
-                    # connect / discover that it is a closed loop
-                    break
-
-                # otherwise proceed to the next way in the list
-                way_ref_index_2 += 1
-
-            # Only proceed onto the next item if we have properly gone through
-            # all the other ways
-            if way_ref_index_2 == len(way_refs):
-                way_ref_index_1 += 1
-
-        return way_refs, output_ways
-
     def relation_to_multi_polygon(
             self,
             relation: Relation
@@ -194,7 +115,7 @@ class OsmToShapely:
                     outer_way_refs.append(member.ref)
 
         # now piece together the outer way
-        incomplete_way_refs, outer_ways_nodes = self._piece_together_ways(
+        incomplete_ways_nodes, outer_ways_nodes = piece_together_ways(
             outer_way_refs,
             outer_way_all_nodes,
             outer_way_start_nodes,
@@ -206,8 +127,11 @@ class OsmToShapely:
         # exterior ways. We fail completely because it's very likely that
         # interior ways will intersect with the incomplete exterior ways.
         # This happens a lot with buildings which have holes in them.
-        if len(incomplete_way_refs) > 0:
-            self.incomplete_refs_handler(relation, incomplete_way_refs)
+        if len(incomplete_ways_nodes) > 0:
+            self.incomplete_refs_handler(
+                relation,
+                incomplete_ways_nodes.keys()
+            )
             return None
 
         # Fail completely if we somehow get no nodes pieced together.
@@ -217,7 +141,7 @@ class OsmToShapely:
 
         # create exteriors of polygons
         exterior_polygons = []
-        for outer_way_nodes in outer_ways_nodes:
+        for outer_way_nodes in outer_ways_nodes.values():
             exterior_nodes = []
             for node in outer_way_nodes:
                 exterior_nodes.append((node.lat, node.lon))
@@ -227,22 +151,25 @@ class OsmToShapely:
             exterior_polygons.append(exterior_polygon)
 
         # now piece together the inner way
-        incomplete_way_refs, inner_ways_nodes = self._piece_together_ways(
+        incomplete_ways_nodes, inner_ways_nodes = piece_together_ways(
             inner_way_refs,
             inner_way_all_nodes,
             inner_way_start_node,
             inner_way_end_node
         )
 
-        if len(incomplete_way_refs) > 0:
+        if len(incomplete_ways_nodes) > 0:
             # Failed to piece together interior way.
             # Continuing as normal, but the shape might look wrong...
-            self.incomplete_refs_handler(relation, incomplete_way_refs)
+            self.incomplete_refs_handler(
+                relation,
+                incomplete_ways_nodes.keys()
+            )
 
         exterior_polygons_interiors = [
             [] for _ in range(len(exterior_polygons))
         ]
-        for inner_way_nodes in inner_ways_nodes:
+        for inner_way_nodes in inner_ways_nodes.values():
             interior_coordinates = []
             for node in inner_way_nodes:
                 interior_coordinates.append((node.lat, node.lon))

--- a/map_engraver/data/osm_shapely/piece_together_ways.py
+++ b/map_engraver/data/osm_shapely/piece_together_ways.py
@@ -1,0 +1,82 @@
+from typing import List, Dict, Tuple
+
+from map_engraver.data.osm import Node
+
+
+def piece_together_ways(
+        way_refs: List[str],
+        way_nodes: Dict[str, List[Node]],
+        way_start_nodes: Dict[str, Node],
+        way_end_nodes: Dict[str, Node]
+) -> Tuple[Dict[str, List[Node]], Dict[str, List[Node]]]:
+    output_ways = dict()
+    way_ref_index_1 = 0
+    while way_ref_index_1 < len(way_refs):
+        # print("----")
+        way_ref_1 = way_refs[way_ref_index_1]
+        # print("ref1 " + str(way_ref_1))
+
+        # way is closed, so delete this way from the list of ways to
+        # process and continue to the next way
+        if way_end_nodes[way_ref_1] == way_start_nodes[way_ref_1]:
+            # print(
+            # "Closed way!",
+            # way_end_nodes[way_ref_1],
+            # way_start_nodes[way_ref_1]
+            # )
+            output_ways[way_ref_1] = way_nodes[way_ref_1]
+
+            del way_refs[way_ref_index_1]
+            del way_nodes[way_ref_1]
+            del way_start_nodes[way_ref_1]
+            del way_end_nodes[way_ref_1]
+            continue
+
+        # go through all other ways (excluding self)
+        way_ref_index_2 = 0
+        while way_ref_index_2 < len(way_refs):
+            way_ref_2 = way_refs[way_ref_index_2]
+            if way_ref_1 == way_ref_2:
+                way_ref_index_2 += 1
+                continue
+
+            # print("ref2 " + str(way_ref_2))
+
+            # if the end node of the current way is connected to the start
+            # node of the other way
+            if way_end_nodes[way_ref_1] == way_start_nodes[way_ref_2]:
+                # remove the first node of the other way to ensure we don't
+                # have redundant nodes and add it to the end of the current
+                # way
+                way_nodes_2 = way_nodes[way_ref_2][1:]
+                way_nodes[way_ref_1].extend(way_nodes_2)
+
+                # updated the linked list attributes
+                way_end_nodes[way_ref_1] = way_end_nodes[way_ref_2]
+
+                # Delete any mention of this way entirely!
+                del way_nodes[way_ref_2]
+                del way_start_nodes[way_ref_2]
+                del way_end_nodes[way_ref_2]
+                del way_refs[way_ref_index_2]
+                # if the index of the other way is behind the current way
+                # index, make sure to change the index because the other
+                # way was removed from the list!
+                way_ref_index_2 -= 1
+                if way_ref_index_1 > way_ref_index_2:
+                    way_ref_index_1 -= 1
+
+                # Break out of this loop. The current way should be
+                # reprocessed in an attempt to discover more ways to
+                # connect / discover that it is a closed loop
+                break
+
+            # otherwise proceed to the next way in the list
+            way_ref_index_2 += 1
+
+        # Only proceed onto the next item if we have properly gone through
+        # all the other ways
+        if way_ref_index_2 == len(way_refs):
+            way_ref_index_1 += 1
+
+    return way_nodes, output_ways

--- a/tests/data/osm_shapely/coastline_data.osm
+++ b/tests/data/osm_shapely/coastline_data.osm
@@ -1,0 +1,171 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osm version='0.6' generator='JOSM'>
+  <bounds minlat='55.9228065' minlon='3.1622601' maxlat='55.9249705' maxlon='3.1670237' origin='CGImap 0.8.3 (1625712 spike-07.openstreetmap.org)' />
+  <bounds minlat='55.9228065' minlon='3.1622601' maxlat='55.9249705' maxlon='3.1670237' origin='OpenStreetMap server' />
+  <node id='-117569' action='modify' visible='true' lat='58.98011099609' lon='5.70279646131' />
+  <node id='-117570' action='modify' visible='true' lat='58.99330531758' lon='5.73145875968' />
+  <node id='-117571' action='modify' visible='true' lat='59.00295161272' lon='5.73176328435' />
+  <node id='-117572' action='modify' visible='true' lat='59.01400623626' lon='5.72552052851' />
+  <node id='-117573' action='modify' visible='true' lat='59.01964978095' lon='5.74424879604' />
+  <node id='-117574' action='modify' visible='true' lat='59.01000816531' lon='5.76130217785' />
+  <node id='-117575' action='modify' visible='true' lat='58.98954017653' lon='5.74790309214' />
+  <node id='-117576' action='modify' visible='true' lat='58.99761903564' lon='5.78368474147' />
+  <node id='-117577' action='modify' visible='true' lat='59.02160912855' lon='5.78672998823' />
+  <node id='-117578' action='modify' visible='true' lat='59.02701634887' lon='5.83042927912' />
+  <node id='-117579' action='modify' visible='true' lat='59.00977297019' lon='5.8048492064' />
+  <node id='-117580' action='modify' visible='true' lat='59.01682812432' lon='5.80439241939' />
+  <node id='-117581' action='modify' visible='true' lat='59.0200416594' lon='5.83088606613' />
+  <node id='-117582' action='modify' visible='true' lat='58.98899105907' lon='5.79738835186' />
+  <node id='-117583' action='modify' visible='true' lat='58.99212875522' lon='5.79464762978' />
+  <node id='-117584' action='modify' visible='true' lat='58.99691319149' lon='5.80393563237' />
+  <node id='-117585' action='modify' visible='true' lat='58.98969706563' lon='5.8165734064' />
+  <node id='-117586' action='modify' visible='true' lat='58.98499008187' lon='5.80591504276' />
+  <node id='-117587' action='modify' visible='true' lat='59.02897527687' lon='5.78490284017' />
+  <node id='-117588' action='modify' visible='true' lat='59.02497894537' lon='5.77576709992' />
+  <node id='-117589' action='modify' visible='true' lat='59.01659297582' lon='5.77256959083' />
+  <node id='-117590' action='modify' visible='true' lat='59.02325489429' lon='5.76099765317' />
+  <node id='-117591' action='modify' visible='true' lat='59.02779993346' lon='5.74516237006' />
+  <node id='-117592' action='modify' visible='true' lat='58.98224404428' lon='5.77713746096' />
+  <node id='-117593' action='modify' visible='true' lat='58.98091017562' lon='5.76967660641' />
+  <node id='-117594' action='modify' visible='true' lat='58.97730062499' lon='5.76632683499' />
+  <node id='-117595' action='modify' visible='true' lat='58.97431853708' lon='5.77059018044' />
+  <node id='-117596' action='modify' visible='true' lat='58.97431853708' lon='5.78398926615' />
+  <node id='-117597' action='modify' visible='true' lat='58.98098863991' lon='5.78475057784' />
+  <node id='-117598' action='modify' visible='true' lat='58.97761451397' lon='5.78779582459' />
+  <node id='-117599' action='modify' visible='true' lat='58.97321980806' lon='5.77683293628' />
+  <node id='-117601' action='modify' visible='true' lat='59.00217155213' lon='5.80448130761' />
+  <node id='-117602' action='modify' visible='true' lat='58.98953086378' lon='5.82617631516' />
+  <node id='-117603' action='modify' visible='true' lat='58.98009312241' lon='5.81443967173' />
+  <node id='-117604' action='modify' visible='true' lat='58.96980080916' lon='5.78854046364' />
+  <node id='-117605' action='modify' visible='true' lat='58.9627800597' lon='5.72605919018' />
+  <node id='-117606' action='modify' visible='true' lat='58.97083612706' lon='5.73459493085' />
+  <node id='-117607' action='modify' visible='true' lat='58.97285271412' lon='5.74810985359' />
+  <node id='-117608' action='modify' visible='true' lat='58.96927777442' lon='5.76856006561' />
+  <node id='-117609' action='modify' visible='true' lat='58.96185171476' lon='5.78136367662' />
+  <node id='-117627' action='modify' visible='true' lat='59.00601779711' lon='5.81728491862' />
+  <node id='-117642' action='modify' visible='true' lat='58.96036875125' lon='5.7251510498' />
+  <node id='-117649' action='modify' visible='true' lat='58.96423556256' lon='5.73744017774' />
+  <node id='-117657' action='modify' visible='true' lat='58.96065972905' lon='5.73406144706' />
+  <node id='-117669' action='modify' visible='true' lat='58.96573676343' lon='5.72459226535' />
+  <node id='-117676' action='modify' visible='true' lat='58.96473973671' lon='5.73052727254' />
+  <node id='-117684' action='modify' visible='true' lat='58.96244761194' lon='5.72874899323' />
+  <node id='-117685' action='modify' visible='true' lat='58.9985996541' lon='5.76553699079' />
+  <node id='-117686' action='modify' visible='true' lat='59.00043144298' lon='5.77620666663' />
+  <node id='-117687' action='modify' visible='true' lat='59.01114545523' lon='5.77709580629' />
+  <node id='-117688' action='modify' visible='true' lat='59.00986361232' lon='5.76891572148' />
+  <node id='-117691' action='modify' visible='true' lat='58.96226424683' lon='5.73161644639' />
+  <node id='-117692' action='modify' visible='true' lat='58.96542735589' lon='5.73370592457' />
+  <node id='-117693' action='modify' visible='true' lat='58.96842974889' lon='5.72659280734' />
+  <node id='-117694' action='modify' visible='true' lat='58.96191710754' lon='5.71741512267' />
+  <node id='-117695' action='modify' visible='true' lat='58.97486913737' lon='5.70800974413' />
+  <node id='-117708' action='modify' visible='true' lat='58.96660567047' lon='5.72078687668' />
+  <node id='-117726' action='modify' visible='true' lat='58.96275575301' lon='5.72241774559' />
+  <node id='-117732' action='modify' visible='true' lat='58.96629592646' lon='5.71100217819'>
+    <tag k='bbox' v='min' />
+  </node>
+  <node id='-117737' action='modify' visible='true' lat='59.01908916802' lon='5.7995794487'>
+    <tag k='bbox' v='max' />
+  </node>
+  <node id='-117747' action='modify' visible='true' lat='58.96310982654' lon='5.79305631638' />
+  <node id='-117755' action='modify' visible='true' lat='58.95540886935' lon='5.78224164963' />
+  <way id='-103777' action='modify' visible='true'>
+    <nd ref='-117569' />
+    <nd ref='-117570' />
+    <nd ref='-117571' />
+    <nd ref='-117572' />
+    <nd ref='-117573' />
+    <nd ref='-117574' />
+    <nd ref='-117575' />
+    <nd ref='-117576' />
+    <nd ref='-117577' />
+    <tag k='natural' v='coastline' />
+  </way>
+  <way id='-103778' action='modify' visible='true'>
+    <nd ref='-117577' />
+    <nd ref='-117578' />
+    <tag k='natural' v='coastline' />
+  </way>
+  <way id='-103779' action='modify' visible='true'>
+    <nd ref='-117578' />
+    <nd ref='-117581' />
+    <nd ref='-117580' />
+    <nd ref='-117579' />
+    <tag k='natural' v='coastline' />
+  </way>
+  <way id='-103780' action='modify' visible='true'>
+    <nd ref='-117582' />
+    <nd ref='-117586' />
+    <nd ref='-117585' />
+    <nd ref='-117584' />
+    <nd ref='-117583' />
+    <nd ref='-117582' />
+    <tag k='natural' v='coastline' />
+  </way>
+  <way id='-103781' action='modify' visible='true'>
+    <nd ref='-117587' />
+    <nd ref='-117588' />
+    <nd ref='-117589' />
+    <nd ref='-117590' />
+    <nd ref='-117591' />
+    <tag k='natural' v='coastline' />
+  </way>
+  <way id='-103782' action='modify' visible='true'>
+    <nd ref='-117592' />
+    <nd ref='-117593' />
+    <nd ref='-117594' />
+    <nd ref='-117595' />
+    <nd ref='-117599' />
+    <nd ref='-117596' />
+    <tag k='natural' v='coastline' />
+  </way>
+  <way id='-103783' action='modify' visible='true'>
+    <nd ref='-117596' />
+    <nd ref='-117598' />
+    <nd ref='-117597' />
+    <nd ref='-117592' />
+    <tag k='natural' v='coastline' />
+  </way>
+  <way id='-103785' action='modify' visible='true'>
+    <nd ref='-117601' />
+    <nd ref='-117627' />
+    <nd ref='-117602' />
+    <nd ref='-117603' />
+    <nd ref='-117604' />
+    <tag k='natural' v='coastline' />
+  </way>
+  <way id='-103788' action='modify' visible='true'>
+    <nd ref='-117604' />
+    <nd ref='-117747' />
+    <nd ref='-117755' />
+    <nd ref='-117609' />
+    <nd ref='-117608' />
+    <nd ref='-117607' />
+    <nd ref='-117606' />
+    <nd ref='-117649' />
+    <nd ref='-117657' />
+    <nd ref='-117642' />
+    <nd ref='-117726' />
+    <nd ref='-117669' />
+    <nd ref='-117676' />
+    <nd ref='-117684' />
+    <nd ref='-117605' />
+    <tag k='natural' v='coastline' />
+  </way>
+  <way id='-103878' action='modify' visible='true'>
+    <nd ref='-117685' />
+    <nd ref='-117688' />
+    <nd ref='-117687' />
+    <nd ref='-117686' />
+    <nd ref='-117685' />
+    <tag k='natural' v='coastline' />
+  </way>
+  <way id='-103895' action='modify' visible='true'>
+    <nd ref='-117691' />
+    <nd ref='-117692' />
+    <nd ref='-117693' />
+    <nd ref='-117708' />
+    <nd ref='-117694' />
+    <nd ref='-117695' />
+    <tag k='natural' v='coastline' />
+  </way>
+</osm>

--- a/tests/data/osm_shapely/coastline_empty_data.osm
+++ b/tests/data/osm_shapely/coastline_empty_data.osm
@@ -1,0 +1,9 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osm version='0.6' generator='JOSM'>
+  <node id='-119114' action='modify' visible='true' lat='51.31689423723' lon='-10.76662353516'>
+    <tag k='bbox' v='min' />
+  </node>
+  <node id='-119115' action='modify' visible='true' lat='52.37561259058' lon='-9.17360595704'>
+    <tag k='bbox' v='max' />
+  </node>
+</osm>

--- a/tests/data/osm_shapely/coastline_incomplete_end_data.osm
+++ b/tests/data/osm_shapely/coastline_incomplete_end_data.osm
@@ -1,0 +1,52 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osm version='0.6' generator='JOSM'>
+  <node id='-119114' action='modify' visible='true' lat='51.31689423723' lon='-10.76662353516'>
+    <tag k='bbox' v='min' />
+  </node>
+  <node id='-119115' action='modify' visible='true' lat='52.37561259058' lon='-9.17360595704'>
+    <tag k='bbox' v='max' />
+  </node>
+  <node id='-119116' action='modify' visible='true' lat='52.24126287701' lon='-9.76685668945' />
+  <node id='-119117' action='modify' visible='true' lat='52.22107625398' lon='-9.95362426758' />
+  <node id='-119118' action='modify' visible='true' lat='52.30176768191' lon='-10.04151489258' />
+  <node id='-119119' action='modify' visible='true' lat='52.16720037398' lon='-10.42603637695' />
+  <node id='-119120' action='modify' visible='true' lat='52.07951275564' lon='-10.45899536133' />
+  <node id='-119121' action='modify' visible='true' lat='52.14023794373' lon='-9.76685668945' />
+  <node id='-119122' action='modify' visible='true' lat='51.9036195863' lon='-10.42603637695' />
+  <node id='-119123' action='modify' visible='true' lat='51.72703496208' lon='-10.1843371582' />
+  <node id='-119124' action='modify' visible='true' lat='51.89006071568' lon='-9.58008911133' />
+  <node id='-119125' action='modify' visible='true' lat='51.5770763648' lon='-10.2282824707' />
+  <node id='-119126' action='modify' visible='true' lat='51.74744543313' lon='-9.33838989258' />
+  <node id='-119127' action='modify' visible='true' lat='51.53609243552' lon='-9.9206652832' />
+  <node id='-119128' action='modify' visible='true' lat='51.6180233702' lon='-9.41529418945' />
+  <node id='-119129' action='modify' visible='true' lat='51.44716719406' lon='-9.8767199707' />
+  <node id='-119130' action='modify' visible='true' lat='51.54975784869' lon='-9.40430786132' />
+  <node id='-119134' action='modify' visible='true' lat='52.28496571482' lon='-9.8822076416' />
+  <node id='-119135' action='modify' visible='true' lat='52.37895588323' lon='-9.81079650879' />
+  <node id='-119136' action='modify' visible='true' lat='52.41917626075' lon='-9.93164611816' />
+  <node id='-119137' action='modify' visible='true' lat='52.48612877598' lon='-9.67896057129' />
+  <node id='-119138' action='modify' visible='true' lat='52.56633748431' lon='-9.6624810791' />
+  <way id='-104922' action='modify' visible='true'>
+    <nd ref='-119138' />
+    <nd ref='-119137' />
+    <nd ref='-119136' />
+    <nd ref='-119135' />
+    <nd ref='-119134' />
+    <nd ref='-119116' />
+    <nd ref='-119117' />
+    <nd ref='-119118' />
+    <nd ref='-119119' />
+    <nd ref='-119120' />
+    <nd ref='-119121' />
+    <nd ref='-119122' />
+    <nd ref='-119123' />
+    <nd ref='-119124' />
+    <nd ref='-119125' />
+    <nd ref='-119126' />
+    <nd ref='-119127' />
+    <nd ref='-119128' />
+    <nd ref='-119129' />
+    <nd ref='-119130' />
+    <tag k='natural' v='coastline' />
+  </way>
+</osm>

--- a/tests/data/osm_shapely/coastline_incomplete_start_data.osm
+++ b/tests/data/osm_shapely/coastline_incomplete_start_data.osm
@@ -1,0 +1,42 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osm version='0.6' generator='JOSM'>
+  <node id='-119013' action='modify' visible='true' lat='51.31689423723' lon='-10.76662353516'>
+    <tag k='bbox' v='min' />
+  </node>
+  <node id='-119014' action='modify' visible='true' lat='52.37561259058' lon='-9.17360595704'>
+    <tag k='bbox' v='max' />
+  </node>
+  <node id='-119099' action='modify' visible='true' lat='52.24126287701' lon='-9.76685668945' />
+  <node id='-119100' action='modify' visible='true' lat='52.22107625398' lon='-9.95362426758' />
+  <node id='-119101' action='modify' visible='true' lat='52.30176768191' lon='-10.04151489258' />
+  <node id='-119102' action='modify' visible='true' lat='52.16720037398' lon='-10.42603637695' />
+  <node id='-119103' action='modify' visible='true' lat='52.07951275564' lon='-10.45899536133' />
+  <node id='-119104' action='modify' visible='true' lat='52.14023794373' lon='-9.76685668945' />
+  <node id='-119105' action='modify' visible='true' lat='51.9036195863' lon='-10.42603637695' />
+  <node id='-119106' action='modify' visible='true' lat='51.72703496208' lon='-10.1843371582' />
+  <node id='-119107' action='modify' visible='true' lat='51.89006071568' lon='-9.58008911133' />
+  <node id='-119108' action='modify' visible='true' lat='51.5770763648' lon='-10.2282824707' />
+  <node id='-119109' action='modify' visible='true' lat='51.74744543313' lon='-9.33838989258' />
+  <node id='-119110' action='modify' visible='true' lat='51.53609243552' lon='-9.9206652832' />
+  <node id='-119111' action='modify' visible='true' lat='51.6180233702' lon='-9.41529418945' />
+  <node id='-119112' action='modify' visible='true' lat='51.44716719406' lon='-9.8767199707' />
+  <node id='-119113' action='modify' visible='true' lat='51.6384830303' lon='-8.4704699707' />
+  <way id='-104898' action='modify' visible='true'>
+    <nd ref='-119099' />
+    <nd ref='-119100' />
+    <nd ref='-119101' />
+    <nd ref='-119102' />
+    <nd ref='-119103' />
+    <nd ref='-119104' />
+    <nd ref='-119105' />
+    <nd ref='-119106' />
+    <nd ref='-119107' />
+    <nd ref='-119108' />
+    <nd ref='-119109' />
+    <nd ref='-119110' />
+    <nd ref='-119111' />
+    <nd ref='-119112' />
+    <nd ref='-119113' />
+    <tag k='natural' v='coastline' />
+  </way>
+</osm>

--- a/tests/data/osm_shapely/coastline_inverse_nested_data.osm
+++ b/tests/data/osm_shapely/coastline_inverse_nested_data.osm
@@ -1,0 +1,197 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osm version='0.6' generator='JOSM'>
+  <node id='-118783' action='modify' visible='true' lat='54.70637592833' lon='-6.22787612915' />
+  <node id='-118784' action='modify' visible='true' lat='54.65238598012' lon='-6.30066055298' />
+  <node id='-118785' action='modify' visible='true' lat='54.60946044788' lon='-6.31851333618' />
+  <node id='-118786' action='modify' visible='true' lat='54.60866510333' lon='-6.26495498657' />
+  <node id='-118787' action='modify' visible='true' lat='54.58161414066' lon='-6.27182144165' />
+  <node id='-118788' action='modify' visible='true' lat='54.55056296538' lon='-6.34597915649' />
+  <node id='-118789' action='modify' visible='true' lat='54.54020731758' lon='-6.32263320923' />
+  <node id='-118790' action='modify' visible='true' lat='54.52347341065' lon='-6.35284561157' />
+  <node id='-118791' action='modify' visible='true' lat='54.49317556753' lon='-6.3377394104' />
+  <node id='-118792' action='modify' visible='true' lat='54.48838964353' lon='-6.41052383423' />
+  <node id='-118793' action='modify' visible='true' lat='54.51311088745' lon='-6.41189712524' />
+  <node id='-118794' action='modify' visible='true' lat='54.51709678445' lon='-6.50528091431' />
+  <node id='-118795' action='modify' visible='true' lat='54.50354314761' lon='-6.54785293579' />
+  <node id='-118796' action='modify' visible='true' lat='54.53542690129' lon='-6.60553115845' />
+  <node id='-118797' action='modify' visible='true' lat='54.62456904192' lon='-6.49841445923' />
+  <node id='-118798' action='modify' visible='true' lat='54.71827581151' lon='-6.53274673462' />
+  <node id='-118799' action='modify' visible='true' lat='54.75633197411' lon='-6.47506851196' />
+  <node id='-118800' action='modify' visible='true' lat='54.71113630067' lon='-6.45584243774' />
+  <node id='-118801' action='modify' visible='true' lat='54.70161499719' lon='-6.35833877563' />
+  <node id='-118802' action='modify' visible='true' lat='54.72700017313' lon='-6.26220840454' />
+  <node id='-118803' action='modify' visible='true' lat='54.49736219331' lon='-7.92800937653' />
+  <node id='-118804' action='modify' visible='true' lat='54.48679361272' lon='-7.96749149323' />
+  <node id='-118805' action='modify' visible='true' lat='54.49636527412' lon='-7.9788211441' />
+  <node id='-118806' action='modify' visible='true' lat='54.5091240035' lon='-7.90569339752' />
+  <node id='-118807' action='modify' visible='true' lat='54.5326374689' lon='-7.85488162994' />
+  <node id='-118808' action='modify' visible='true' lat='54.52825462922' lon='-7.75257144928' />
+  <node id='-118809' action='modify' visible='true' lat='54.51789331933' lon='-7.73746524811' />
+  <node id='-118810' action='modify' visible='true' lat='54.49696342855' lon='-7.77969394684' />
+  <node id='-118811' action='modify' visible='true' lat='54.39035398746' lon='-7.6533511734' />
+  <node id='-118812' action='modify' visible='true' lat='54.35495588963' lon='-7.65918766022' />
+  <node id='-118813' action='modify' visible='true' lat='54.41253722776' lon='-7.69695316315' />
+  <node id='-118814' action='modify' visible='true' lat='54.46814237901' lon='-8.0101493454' />
+  <node id='-118815' action='modify' visible='true' lat='54.47682074891' lon='-8.01006351471' />
+  <node id='-118816' action='modify' visible='true' lat='54.48716754781' lon='-7.95341526031' />
+  <node id='-118817' action='modify' visible='true' lat='54.49616573782' lon='-7.92715081215' />
+  <node id='-118818' action='modify' visible='true' lat='54.5282545296' lon='-7.79308336258' />
+  <node id='-118819' action='modify' visible='true' lat='54.52436934648' lon='-7.8346254158' />
+  <node id='-118820' action='modify' visible='true' lat='54.51141606584' lon='-7.86844270706' />
+  <node id='-118821' action='modify' visible='true' lat='54.50952254995' lon='-7.89522188187' />
+  <node id='-118822' action='modify' visible='true' lat='54.50523690043' lon='-7.86466615677' />
+  <node id='-118823' action='modify' visible='true' lat='54.51061880669' lon='-7.83874528885' />
+  <node id='-118824' action='modify' visible='true' lat='54.51829178023' lon='-7.8123094368' />
+  <node id='-118825' action='modify' visible='true' lat='54.51311018988' lon='-7.80458467484' />
+  <node id='-118826' action='modify' visible='true' lat='54.52586369144' lon='-7.78724687576' />
+  <node id='-118827' action='modify' visible='true' lat='54.49574822504' lon='-7.93134571195' />
+  <node id='-118828' action='modify' visible='true' lat='54.49536813746' lon='-7.93145300031' />
+  <node id='-118829' action='modify' visible='true' lat='54.49512512879' lon='-7.9324615109' />
+  <node id='-118830' action='modify' visible='true' lat='54.49525597979' lon='-7.93281556249' />
+  <node id='-118831' action='modify' visible='true' lat='54.49514382182' lon='-7.9337704289' />
+  <node id='-118832' action='modify' visible='true' lat='54.49566099214' lon='-7.9332661736' />
+  <node id='-118833' action='modify' visible='true' lat='54.49592269028' lon='-7.9320752728' />
+  <node id='-118834' action='modify' visible='true' lat='54.59456924383' lon='-6.29555229664' />
+  <node id='-118835' action='modify' visible='true' lat='54.59158553056' lon='-6.2988138628' />
+  <node id='-118836' action='modify' visible='true' lat='54.58753230325' lon='-6.30224709034' />
+  <node id='-118837' action='modify' visible='true' lat='54.58574179221' lon='-6.30816940784' />
+  <node id='-118838' action='modify' visible='true' lat='54.58367763323' lon='-6.30941395283' />
+  <node id='-118839' action='modify' visible='true' lat='54.58290665545' lon='-6.30632404804' />
+  <node id='-118840' action='modify' visible='true' lat='54.58482163787' lon='-6.30422119617' />
+  <node id='-118841' action='modify' visible='true' lat='54.58845239637' lon='-6.29885677814' />
+  <node id='-118842' action='modify' visible='true' lat='54.59138660857' lon='-6.29786972523' />
+  <node id='-118843' action='modify' visible='true' lat='54.59442006336' lon='-6.29370693684' />
+  <node id='-118844' action='modify' visible='true' lat='54.49571083486' lon='-7.93163270026' />
+  <node id='-118845' action='modify' visible='true' lat='54.49569369982' lon='-7.93180436164' />
+  <node id='-118846' action='modify' visible='true' lat='54.49560490907' lon='-7.93168902665' />
+  <node id='-118847' action='modify' visible='true' lat='54.49566254519' lon='-7.93153077632' />
+  <node id='-118875' action='modify' visible='true' lat='54.4748260838' lon='-7.85247871399' />
+  <node id='-118876' action='modify' visible='true' lat='54.48978499765' lon='-7.71823917389' />
+  <node id='-118877' action='modify' visible='true' lat='54.46824214085' lon='-7.74742160797' />
+  <node id='-118878' action='modify' visible='true' lat='54.43450878504' lon='-7.70759616852' />
+  <node id='-118879' action='modify' visible='true' lat='54.43730432014' lon='-7.69145999908' />
+  <node id='-118880' action='modify' visible='true' lat='54.53303588554' lon='-7.78381381989' />
+  <node id='-118881' action='modify' visible='true' lat='54.53004766596' lon='-7.80647312164' />
+  <node id='-118882' action='modify' visible='true' lat='54.52666075267' lon='-7.78141056061' />
+  <node id='-118883' action='modify' visible='true' lat='54.47532443503' lon='-7.97723297596' />
+  <node id='-118884' action='modify' visible='true' lat='54.4822062229' lon='-7.98864845753' />
+  <node id='-118885' action='modify' visible='true' lat='54.47557379539' lon='-7.9922104311' />
+  <node id='-118886' action='modify' visible='true' lat='51.1655803768' lon='-11.18410400391'>
+    <tag k='bbox' v='min' />
+  </node>
+  <node id='-118887' action='modify' visible='true' lat='55.57835709286' lon='-4.83400634766'>
+    <tag k='bbox' v='max' />
+  </node>
+  <node id='-118888' action='modify' visible='true' lat='54.49568668925' lon='-7.93164074555' />
+  <node id='-118889' action='modify' visible='true' lat='54.49566488101' lon='-7.93161258236' />
+  <node id='-118890' action='modify' visible='true' lat='54.49564930369' lon='-7.93166488543' />
+  <node id='-118891' action='modify' visible='true' lat='54.49567500627' lon='-7.93169841304' />
+  <way id='-104871' action='modify' visible='true'>
+    <nd ref='-118783' />
+    <nd ref='-118784' />
+    <nd ref='-118785' />
+    <nd ref='-118786' />
+    <nd ref='-118787' />
+    <nd ref='-118788' />
+    <nd ref='-118789' />
+    <nd ref='-118790' />
+    <nd ref='-118791' />
+    <nd ref='-118792' />
+    <nd ref='-118793' />
+    <nd ref='-118794' />
+    <nd ref='-118795' />
+    <nd ref='-118796' />
+    <nd ref='-118797' />
+    <nd ref='-118798' />
+    <nd ref='-118799' />
+    <nd ref='-118800' />
+    <nd ref='-118801' />
+    <nd ref='-118802' />
+    <nd ref='-118783' />
+    <tag k='natural' v='coastline' />
+  </way>
+  <way id='-104872' action='modify' visible='true'>
+    <nd ref='-118803' />
+    <nd ref='-118804' />
+    <nd ref='-118805' />
+    <nd ref='-118806' />
+    <nd ref='-118807' />
+    <nd ref='-118881' />
+    <nd ref='-118880' />
+    <nd ref='-118882' />
+    <nd ref='-118808' />
+    <nd ref='-118809' />
+    <nd ref='-118810' />
+    <nd ref='-118876' />
+    <nd ref='-118877' />
+    <nd ref='-118878' />
+    <nd ref='-118879' />
+    <nd ref='-118811' />
+    <nd ref='-118812' />
+    <nd ref='-118813' />
+    <nd ref='-118875' />
+    <nd ref='-118814' />
+    <nd ref='-118815' />
+    <nd ref='-118884' />
+    <nd ref='-118885' />
+    <nd ref='-118883' />
+    <nd ref='-118816' />
+    <nd ref='-118817' />
+    <nd ref='-118803' />
+    <tag k='natural' v='coastline' />
+  </way>
+  <way id='-104873' action='modify' visible='true'>
+    <nd ref='-118818' />
+    <nd ref='-118819' />
+    <nd ref='-118820' />
+    <nd ref='-118821' />
+    <nd ref='-118822' />
+    <nd ref='-118823' />
+    <nd ref='-118824' />
+    <nd ref='-118825' />
+    <nd ref='-118826' />
+    <nd ref='-118818' />
+    <tag k='natural' v='coastline' />
+  </way>
+  <way id='-104874' action='modify' visible='true'>
+    <nd ref='-118827' />
+    <nd ref='-118828' />
+    <nd ref='-118829' />
+    <nd ref='-118830' />
+    <nd ref='-118831' />
+    <nd ref='-118832' />
+    <nd ref='-118833' />
+    <nd ref='-118827' />
+    <tag k='natural' v='coastline' />
+  </way>
+  <way id='-104875' action='modify' visible='true'>
+    <nd ref='-118834' />
+    <nd ref='-118835' />
+    <nd ref='-118836' />
+    <nd ref='-118837' />
+    <nd ref='-118838' />
+    <nd ref='-118839' />
+    <nd ref='-118840' />
+    <nd ref='-118841' />
+    <nd ref='-118842' />
+    <nd ref='-118843' />
+    <nd ref='-118834' />
+    <tag k='natural' v='coastline' />
+  </way>
+  <way id='-104876' action='modify' visible='true'>
+    <nd ref='-118844' />
+    <nd ref='-118845' />
+    <nd ref='-118846' />
+    <nd ref='-118847' />
+    <nd ref='-118844' />
+    <tag k='natural' v='coastline' />
+  </way>
+  <way id='-104877' action='modify' visible='true'>
+    <nd ref='-118888' />
+    <nd ref='-118889' />
+    <nd ref='-118890' />
+    <nd ref='-118891' />
+    <nd ref='-118888' />
+    <tag k='natural' v='coastline' />
+  </way>
+</osm>

--- a/tests/data/osm_shapely/coastline_lake_in_land_data.osm
+++ b/tests/data/osm_shapely/coastline_lake_in_land_data.osm
@@ -1,0 +1,53 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osm version='0.6' generator='JOSM'>
+  <node id='-117849' action='modify' visible='true' lat='54.70637592833' lon='-6.22787612915' />
+  <node id='-117850' action='modify' visible='true' lat='54.65238598012' lon='-6.30066055298' />
+  <node id='-117851' action='modify' visible='true' lat='54.60946044788' lon='-6.31851333618' />
+  <node id='-117852' action='modify' visible='true' lat='54.60866510333' lon='-6.26495498657' />
+  <node id='-117853' action='modify' visible='true' lat='54.58161414066' lon='-6.27182144165' />
+  <node id='-117854' action='modify' visible='true' lat='54.55056296538' lon='-6.34597915649' />
+  <node id='-117855' action='modify' visible='true' lat='54.54020731758' lon='-6.32263320923' />
+  <node id='-117856' action='modify' visible='true' lat='54.52347341065' lon='-6.35284561157' />
+  <node id='-117857' action='modify' visible='true' lat='54.49317556753' lon='-6.3377394104' />
+  <node id='-117858' action='modify' visible='true' lat='54.48838964353' lon='-6.41052383423' />
+  <node id='-117859' action='modify' visible='true' lat='54.51311088745' lon='-6.41189712524' />
+  <node id='-117860' action='modify' visible='true' lat='54.51709678445' lon='-6.50528091431' />
+  <node id='-117861' action='modify' visible='true' lat='54.50354314761' lon='-6.54785293579' />
+  <node id='-117862' action='modify' visible='true' lat='54.53542690129' lon='-6.60553115845' />
+  <node id='-117863' action='modify' visible='true' lat='54.62456904192' lon='-6.49841445923' />
+  <node id='-117864' action='modify' visible='true' lat='54.71827581151' lon='-6.53274673462' />
+  <node id='-117865' action='modify' visible='true' lat='54.75633197411' lon='-6.47506851196' />
+  <node id='-117866' action='modify' visible='true' lat='54.71113630067' lon='-6.45584243774' />
+  <node id='-117867' action='modify' visible='true' lat='54.70161499719' lon='-6.35833877563' />
+  <node id='-117868' action='modify' visible='true' lat='54.72700017313' lon='-6.26220840454' />
+  <node id='-118627' action='modify' visible='true' lat='54.3997609465' lon='-6.72365478516'>
+    <tag k='bbox' v='min' />
+  </node>
+  <node id='-118628' action='modify' visible='true' lat='54.81969136385' lon='-6.05348876953'>
+    <tag k='bbox' v='max' />
+  </node>
+  <way id='-104013' action='modify' visible='true'>
+    <nd ref='-117849' />
+    <nd ref='-117850' />
+    <nd ref='-117851' />
+    <nd ref='-117852' />
+    <nd ref='-117853' />
+    <nd ref='-117854' />
+    <nd ref='-117855' />
+    <nd ref='-117856' />
+    <nd ref='-117857' />
+    <nd ref='-117858' />
+    <nd ref='-117859' />
+    <nd ref='-117860' />
+    <nd ref='-117861' />
+    <nd ref='-117862' />
+    <nd ref='-117863' />
+    <nd ref='-117864' />
+    <nd ref='-117865' />
+    <nd ref='-117866' />
+    <nd ref='-117867' />
+    <nd ref='-117868' />
+    <nd ref='-117849' />
+    <tag k='natural' v='coastline' />
+  </way>
+</osm>

--- a/tests/data/osm_shapely/coastline_nested_data.osm
+++ b/tests/data/osm_shapely/coastline_nested_data.osm
@@ -1,0 +1,281 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osm version='0.6' generator='JOSM'>
+  <node id='-117835' action='modify' visible='true' lat='55.22276335448' lon='-6.15235473633' />
+  <node id='-117836' action='modify' visible='true' lat='55.23529430441' lon='-8.17383911133' />
+  <node id='-117837' action='modify' visible='true' lat='54.27806127406' lon='-8.75611450195' />
+  <node id='-117838' action='modify' visible='true' lat='54.29088805896' lon='-10.0085559082' />
+  <node id='-117839' action='modify' visible='true' lat='53.39643867797' lon='-10.15137817383' />
+  <node id='-117840' action='modify' visible='true' lat='53.1928768258' lon='-9.07471801758' />
+  <node id='-117841' action='modify' visible='true' lat='52.05249723193' lon='-10.5358996582' />
+  <node id='-117842' action='modify' visible='true' lat='51.46770380022' lon='-9.28620483398' />
+  <node id='-117843' action='modify' visible='true' lat='52.10651193851' lon='-7.47071411133' />
+  <node id='-117844' action='modify' visible='true' lat='52.18741148111' lon='-6.3610949707' />
+  <node id='-117845' action='modify' visible='true' lat='52.92878114844' lon='-6.02051879883' />
+  <node id='-117846' action='modify' visible='true' lat='53.99486042403' lon='-6.32813598633' />
+  <node id='-117847' action='modify' visible='true' lat='54.39655671032' lon='-5.41627075195' />
+  <node id='-117849' action='modify' visible='true' lat='54.70637592833' lon='-6.22787612915' />
+  <node id='-117850' action='modify' visible='true' lat='54.65238598012' lon='-6.30066055298' />
+  <node id='-117851' action='modify' visible='true' lat='54.60946044788' lon='-6.31851333618' />
+  <node id='-117852' action='modify' visible='true' lat='54.60866510333' lon='-6.26495498657' />
+  <node id='-117853' action='modify' visible='true' lat='54.58161414066' lon='-6.27182144165' />
+  <node id='-117854' action='modify' visible='true' lat='54.55056296538' lon='-6.34597915649' />
+  <node id='-117855' action='modify' visible='true' lat='54.54020731758' lon='-6.32263320923' />
+  <node id='-117856' action='modify' visible='true' lat='54.52347341065' lon='-6.35284561157' />
+  <node id='-117857' action='modify' visible='true' lat='54.49317556753' lon='-6.3377394104' />
+  <node id='-117858' action='modify' visible='true' lat='54.48838964353' lon='-6.41052383423' />
+  <node id='-117859' action='modify' visible='true' lat='54.51311088745' lon='-6.41189712524' />
+  <node id='-117860' action='modify' visible='true' lat='54.51709678445' lon='-6.50528091431' />
+  <node id='-117861' action='modify' visible='true' lat='54.50354314761' lon='-6.54785293579' />
+  <node id='-117862' action='modify' visible='true' lat='54.53542690129' lon='-6.60553115845' />
+  <node id='-117863' action='modify' visible='true' lat='54.62456904192' lon='-6.49841445923' />
+  <node id='-117864' action='modify' visible='true' lat='54.71827581151' lon='-6.53274673462' />
+  <node id='-117865' action='modify' visible='true' lat='54.75633197411' lon='-6.47506851196' />
+  <node id='-117866' action='modify' visible='true' lat='54.71113630067' lon='-6.45584243774' />
+  <node id='-117867' action='modify' visible='true' lat='54.70161499719' lon='-6.35833877563' />
+  <node id='-117868' action='modify' visible='true' lat='54.72700017313' lon='-6.26220840454' />
+  <node id='-117870' action='modify' visible='true' lat='54.49736219331' lon='-7.92800937653' />
+  <node id='-117871' action='modify' visible='true' lat='54.48679361272' lon='-7.96749149323' />
+  <node id='-117872' action='modify' visible='true' lat='54.49636527412' lon='-7.9788211441' />
+  <node id='-117873' action='modify' visible='true' lat='54.5091240035' lon='-7.90569339752' />
+  <node id='-117874' action='modify' visible='true' lat='54.5326374689' lon='-7.85488162994' />
+  <node id='-117875' action='modify' visible='true' lat='54.52825462922' lon='-7.75257144928' />
+  <node id='-117876' action='modify' visible='true' lat='54.51789331933' lon='-7.73746524811' />
+  <node id='-117877' action='modify' visible='true' lat='54.49696342855' lon='-7.77969394684' />
+  <node id='-117878' action='modify' visible='true' lat='54.39035398746' lon='-7.6533511734' />
+  <node id='-117879' action='modify' visible='true' lat='54.35495588963' lon='-7.65918766022' />
+  <node id='-117880' action='modify' visible='true' lat='54.41253722776' lon='-7.69695316315' />
+  <node id='-117882' action='modify' visible='true' lat='54.46814237901' lon='-8.0101493454' />
+  <node id='-117883' action='modify' visible='true' lat='54.47682074891' lon='-8.01006351471' />
+  <node id='-117884' action='modify' visible='true' lat='54.48716754781' lon='-7.95341526031' />
+  <node id='-117885' action='modify' visible='true' lat='54.49616573782' lon='-7.92715081215' />
+  <node id='-117887' action='modify' visible='true' lat='54.5282545296' lon='-7.79308336258' />
+  <node id='-117888' action='modify' visible='true' lat='54.52436934648' lon='-7.8346254158' />
+  <node id='-117889' action='modify' visible='true' lat='54.51141606584' lon='-7.86844270706' />
+  <node id='-117890' action='modify' visible='true' lat='54.50952254995' lon='-7.89522188187' />
+  <node id='-117891' action='modify' visible='true' lat='54.50523690043' lon='-7.86466615677' />
+  <node id='-117892' action='modify' visible='true' lat='54.51061880669' lon='-7.83874528885' />
+  <node id='-117893' action='modify' visible='true' lat='54.51829178023' lon='-7.8123094368' />
+  <node id='-117894' action='modify' visible='true' lat='54.51311018988' lon='-7.80458467484' />
+  <node id='-117895' action='modify' visible='true' lat='54.52586369144' lon='-7.78724687576' />
+  <node id='-117897' action='modify' visible='true' lat='54.49574822504' lon='-7.93134571195' />
+  <node id='-117898' action='modify' visible='true' lat='54.49536813746' lon='-7.93145300031' />
+  <node id='-117899' action='modify' visible='true' lat='54.49512512879' lon='-7.9324615109' />
+  <node id='-117900' action='modify' visible='true' lat='54.49525597979' lon='-7.93281556249' />
+  <node id='-117901' action='modify' visible='true' lat='54.49514382182' lon='-7.9337704289' />
+  <node id='-117902' action='modify' visible='true' lat='54.49566099214' lon='-7.9332661736' />
+  <node id='-117903' action='modify' visible='true' lat='54.49592269028' lon='-7.9320752728' />
+  <node id='-117904' action='modify' visible='true' lat='54.59456924383' lon='-6.29555229664' />
+  <node id='-117905' action='modify' visible='true' lat='54.59158553056' lon='-6.2988138628' />
+  <node id='-117906' action='modify' visible='true' lat='54.58753230325' lon='-6.30224709034' />
+  <node id='-117907' action='modify' visible='true' lat='54.58574179221' lon='-6.30816940784' />
+  <node id='-117908' action='modify' visible='true' lat='54.58367763323' lon='-6.30941395283' />
+  <node id='-117909' action='modify' visible='true' lat='54.58290665545' lon='-6.30632404804' />
+  <node id='-117910' action='modify' visible='true' lat='54.58482163787' lon='-6.30422119617' />
+  <node id='-117911' action='modify' visible='true' lat='54.58845239637' lon='-6.29885677814' />
+  <node id='-117912' action='modify' visible='true' lat='54.59138660857' lon='-6.29786972523' />
+  <node id='-117913' action='modify' visible='true' lat='54.59442006336' lon='-6.29370693684' />
+  <node id='-117929' action='modify' visible='true' lat='54.49571083486' lon='-7.93163270026' />
+  <node id='-117930' action='modify' visible='true' lat='54.49569369982' lon='-7.93180436164' />
+  <node id='-117931' action='modify' visible='true' lat='54.49560490907' lon='-7.93168902665' />
+  <node id='-117932' action='modify' visible='true' lat='54.49566254519' lon='-7.93153077632' />
+  <node id='-117954' action='modify' visible='true' lat='54.59116916086' lon='-8.15186645508' />
+  <node id='-117969' action='modify' visible='true' lat='54.65477496483' lon='-8.87696411133' />
+  <node id='-117981' action='modify' visible='true' lat='53.8330871962' lon='-9.67896606445' />
+  <node id='-117998' action='modify' visible='true' lat='53.8978716959' lon='-10.16236450195' />
+  <node id='-118012' action='modify' visible='true' lat='53.62510200432' lon='-10.15137817383' />
+  <node id='-118041' action='modify' visible='true' lat='52.59638133285' lon='-9.89869262695' />
+  <node id='-118055' action='modify' visible='true' lat='52.69636773642' lon='-8.71216918945' />
+  <node id='-118068' action='modify' visible='true' lat='52.52959668298' lon='-9.68995239258' />
+  <node id='-118092' action='modify' visible='true' lat='52.30176768191' lon='-9.90967895508' />
+  <node id='-118112' action='modify' visible='true' lat='52.16046129733' lon='-9.76685668945' />
+  <node id='-118128' action='modify' visible='true' lat='51.89006071568' lon='-10.50294067383' />
+  <node id='-118148' action='modify' visible='true' lat='51.73383947674' lon='-10.10743286133' />
+  <node id='-118168' action='modify' visible='true' lat='51.89006071568' lon='-9.62403442383' />
+  <node id='-118184' action='modify' visible='true' lat='51.5907243495' lon='-10.24750030518' />
+  <node id='-118212' action='modify' visible='true' lat='51.71852277345' lon='-9.43451202393' />
+  <node id='-118224' action='modify' visible='true' lat='51.54462867533' lon='-9.8629788208' />
+  <node id='-118240' action='modify' visible='true' lat='51.61631286575' lon='-9.53064239502' />
+  <node id='-118253' action='modify' visible='true' lat='51.44716205875' lon='-9.84924591064' />
+  <node id='-118302' action='modify' visible='true' lat='53.97548071883' lon='-6.06446411133' />
+  <node id='-118322' action='modify' visible='true' lat='55.35414155596' lon='-7.26197387695' />
+  <node id='-118339' action='modify' visible='true' lat='55.05950152265' lon='-7.25098754883' />
+  <node id='-118357' action='modify' visible='true' lat='55.23529117217' lon='-6.91040588379' />
+  <node id='-118371' action='modify' visible='true' lat='55.16004623694' lon='-6.94336486816' />
+  <node id='-118384' action='modify' visible='true' lat='55.04061747528' lon='-7.06421447754' />
+  <node id='-118403' action='modify' visible='true' lat='54.78168526789' lon='-5.69092346191' />
+  <node id='-118423' action='modify' visible='true' lat='54.63252106514' lon='-5.94910217285' />
+  <node id='-118441' action='modify' visible='true' lat='54.68018627292' lon='-5.5316217041' />
+  <node id='-118463' action='modify' visible='true' lat='54.4748260838' lon='-7.85247871399' />
+  <node id='-118478' action='modify' visible='true' lat='54.48978499765' lon='-7.71823917389' />
+  <node id='-118494' action='modify' visible='true' lat='54.46824214085' lon='-7.74742160797' />
+  <node id='-118504' action='modify' visible='true' lat='54.43450878504' lon='-7.70759616852' />
+  <node id='-118524' action='modify' visible='true' lat='54.43730432014' lon='-7.69145999908' />
+  <node id='-118545' action='modify' visible='true' lat='54.53303588554' lon='-7.78381381989' />
+  <node id='-118556' action='modify' visible='true' lat='54.53004766596' lon='-7.80647312164' />
+  <node id='-118567' action='modify' visible='true' lat='54.52666075267' lon='-7.78141056061' />
+  <node id='-118590' action='modify' visible='true' lat='54.47532443503' lon='-7.97723297596' />
+  <node id='-118607' action='modify' visible='true' lat='54.4822062229' lon='-7.98864845753' />
+  <node id='-118626' action='modify' visible='true' lat='54.47557379539' lon='-7.9922104311' />
+  <node id='-118627' action='modify' visible='true' lat='51.1655803768' lon='-11.18410400391'>
+    <tag k='bbox' v='min' />
+  </node>
+  <node id='-118628' action='modify' visible='true' lat='55.57835709286' lon='-4.83400634766'>
+    <tag k='bbox' v='max' />
+  </node>
+  <node id='-118662' action='modify' visible='true' lat='54.49568668925' lon='-7.93164074555' />
+  <node id='-118663' action='modify' visible='true' lat='54.49566488101' lon='-7.93161258236' />
+  <node id='-118664' action='modify' visible='true' lat='54.49564930369' lon='-7.93166488543' />
+  <node id='-118665' action='modify' visible='true' lat='54.49567500627' lon='-7.93169841304' />
+  <way id='-104000' action='modify' visible='true'>
+    <nd ref='-117835' />
+    <nd ref='-118371' />
+    <nd ref='-118384' />
+    <nd ref='-118339' />
+    <nd ref='-118357' />
+    <nd ref='-118322' />
+    <nd ref='-117836' />
+    <nd ref='-117969' />
+    <nd ref='-117954' />
+    <nd ref='-117837' />
+    <nd ref='-117838' />
+    <nd ref='-117998' />
+    <nd ref='-117981' />
+    <nd ref='-118012' />
+    <nd ref='-117839' />
+    <nd ref='-117840' />
+    <nd ref='-118041' />
+    <nd ref='-118055' />
+    <nd ref='-118068' />
+    <nd ref='-118092' />
+    <nd ref='-117841' />
+    <nd ref='-118112' />
+    <nd ref='-118128' />
+    <nd ref='-118148' />
+    <nd ref='-118168' />
+    <nd ref='-118184' />
+    <nd ref='-118212' />
+    <nd ref='-118224' />
+    <nd ref='-118240' />
+    <nd ref='-118253' />
+    <nd ref='-117842' />
+    <nd ref='-117843' />
+    <nd ref='-117844' />
+    <nd ref='-117845' />
+    <nd ref='-117846' />
+    <nd ref='-118302' />
+    <nd ref='-117847' />
+    <nd ref='-118441' />
+    <nd ref='-118423' />
+    <nd ref='-118403' />
+    <nd ref='-117835' />
+    <tag k='natural' v='coastline' />
+  </way>
+  <way id='-104013' action='modify' visible='true'>
+    <nd ref='-117849' />
+    <nd ref='-117850' />
+    <nd ref='-117851' />
+    <nd ref='-117852' />
+    <nd ref='-117853' />
+    <nd ref='-117854' />
+    <nd ref='-117855' />
+    <nd ref='-117856' />
+    <nd ref='-117857' />
+    <nd ref='-117858' />
+    <nd ref='-117859' />
+    <nd ref='-117860' />
+    <nd ref='-117861' />
+    <nd ref='-117862' />
+    <nd ref='-117863' />
+    <nd ref='-117864' />
+    <nd ref='-117865' />
+    <nd ref='-117866' />
+    <nd ref='-117867' />
+    <nd ref='-117868' />
+    <nd ref='-117849' />
+    <tag k='natural' v='coastline' />
+  </way>
+  <way id='-104033' action='modify' visible='true'>
+    <nd ref='-117870' />
+    <nd ref='-117871' />
+    <nd ref='-117872' />
+    <nd ref='-117873' />
+    <nd ref='-117874' />
+    <nd ref='-118556' />
+    <nd ref='-118545' />
+    <nd ref='-118567' />
+    <nd ref='-117875' />
+    <nd ref='-117876' />
+    <nd ref='-117877' />
+    <nd ref='-118478' />
+    <nd ref='-118494' />
+    <nd ref='-118504' />
+    <nd ref='-118524' />
+    <nd ref='-117878' />
+    <nd ref='-117879' />
+    <nd ref='-117880' />
+    <nd ref='-118463' />
+    <nd ref='-117882' />
+    <nd ref='-117883' />
+    <nd ref='-118607' />
+    <nd ref='-118626' />
+    <nd ref='-118590' />
+    <nd ref='-117884' />
+    <nd ref='-117885' />
+    <nd ref='-117870' />
+    <tag k='natural' v='coastline' />
+  </way>
+  <way id='-104049' action='modify' visible='true'>
+    <nd ref='-117887' />
+    <nd ref='-117888' />
+    <nd ref='-117889' />
+    <nd ref='-117890' />
+    <nd ref='-117891' />
+    <nd ref='-117892' />
+    <nd ref='-117893' />
+    <nd ref='-117894' />
+    <nd ref='-117895' />
+    <nd ref='-117887' />
+    <tag k='natural' v='coastline' />
+  </way>
+  <way id='-104058' action='modify' visible='true'>
+    <nd ref='-117897' />
+    <nd ref='-117898' />
+    <nd ref='-117899' />
+    <nd ref='-117900' />
+    <nd ref='-117901' />
+    <nd ref='-117902' />
+    <nd ref='-117903' />
+    <nd ref='-117897' />
+    <tag k='natural' v='coastline' />
+  </way>
+  <way id='-104065' action='modify' visible='true'>
+    <nd ref='-117904' />
+    <nd ref='-117905' />
+    <nd ref='-117906' />
+    <nd ref='-117907' />
+    <nd ref='-117908' />
+    <nd ref='-117909' />
+    <nd ref='-117910' />
+    <nd ref='-117911' />
+    <nd ref='-117912' />
+    <nd ref='-117913' />
+    <nd ref='-117904' />
+    <tag k='natural' v='coastline' />
+  </way>
+  <way id='-104122' action='modify' visible='true'>
+    <nd ref='-117929' />
+    <nd ref='-117930' />
+    <nd ref='-117931' />
+    <nd ref='-117932' />
+    <nd ref='-117929' />
+    <tag k='natural' v='coastline' />
+  </way>
+  <way id='-104845' action='modify' visible='true'>
+    <nd ref='-118662' />
+    <nd ref='-118663' />
+    <nd ref='-118664' />
+    <nd ref='-118665' />
+    <nd ref='-118662' />
+    <tag k='natural' v='coastline' />
+  </way>
+</osm>

--- a/tests/data/osm_shapely/test_natural_coastline.py
+++ b/tests/data/osm_shapely/test_natural_coastline.py
@@ -1,7 +1,7 @@
 import unittest
 from pathlib import Path
 
-from map_engraver.data.osm import Parser, Node
+from map_engraver.data.osm import Parser
 from map_engraver.data.osm.filter import filter_elements
 from map_engraver.data.osm_shapely.natural_coastline import \
     natural_coastline_to_multi_polygon, CoastlineOutputType
@@ -30,6 +30,19 @@ class TestNaturalCoastline(unittest.TestCase):
             max_node = bbox_nodes[0]
 
         bounds = (min_node.lat, min_node.lon, max_node.lat, max_node.lon)
-        print(bounds)
 
-        natural_coastline_to_multi_polygon(osm_map, bounds, CoastlineOutputType.LAND)
+        land = natural_coastline_to_multi_polygon(
+            osm_map,
+            bounds,
+            CoastlineOutputType.LAND
+        )
+
+        self.assertEqual(len(land.geoms), 8)
+
+        water = natural_coastline_to_multi_polygon(
+            osm_map,
+            bounds,
+            CoastlineOutputType.WATER
+        )
+
+        self.assertEqual(len(water.geoms), 3)

--- a/tests/data/osm_shapely/test_natural_coastline.py
+++ b/tests/data/osm_shapely/test_natural_coastline.py
@@ -1,15 +1,19 @@
 import unittest
 from pathlib import Path
+from typing import Tuple
 
-from map_engraver.data.osm import Parser
+from map_engraver.data.osm import Parser, Osm
 from map_engraver.data.osm.filter import filter_elements
 from map_engraver.data.osm_shapely.natural_coastline import \
     natural_coastline_to_multi_polygon, CoastlineOutputType
 
 
 class TestNaturalCoastline(unittest.TestCase):
-    def test_natural_coastline_conversion(self):
-        path = Path(__file__).parent.joinpath('coastline_data.osm')
+    def parse_osm(
+            self,
+            filename: str
+    ) -> Tuple[Osm, Tuple[float, float, float, float]]:
+        path = Path(__file__).parent.joinpath(filename)
 
         osm_map = Parser.parse(path)
 
@@ -22,7 +26,11 @@ class TestNaturalCoastline(unittest.TestCase):
             filter_relations=False
         ).nodes.values())
 
-        assert len(bbox_nodes) == 2
+        self.assertEqual(
+            len(bbox_nodes),
+            2,
+            'OSM file did not contain bbox nodes.'
+        )
         min_node = bbox_nodes[0]
         max_node = bbox_nodes[1]
         if bbox_nodes[1].tags['bbox'] == 'min':
@@ -30,6 +38,11 @@ class TestNaturalCoastline(unittest.TestCase):
             max_node = bbox_nodes[0]
 
         bounds = (min_node.lat, min_node.lon, max_node.lat, max_node.lon)
+
+        return osm_map, bounds
+
+    def test_incomplete_natural_coastline(self):
+        osm_map, bounds = self.parse_osm('coastline_data.osm')
 
         land = natural_coastline_to_multi_polygon(
             osm_map,
@@ -46,3 +59,83 @@ class TestNaturalCoastline(unittest.TestCase):
         )
 
         self.assertEqual(len(water.geoms), 3)
+
+    def test_map_with_only_lake_coastline_returns_land_safely(self):
+        osm_map, bounds = self.parse_osm('coastline_lake_in_land_data.osm')
+
+        land = natural_coastline_to_multi_polygon(
+            osm_map,
+            bounds,
+            CoastlineOutputType.LAND
+        )
+        self.assertEqual(len(land.geoms), 1)
+        self.assertEqual(len(land.geoms[0].interiors), 1)
+
+        water = natural_coastline_to_multi_polygon(
+            osm_map,
+            bounds,
+            CoastlineOutputType.WATER
+        )
+        self.assertEqual(len(water.geoms), 1)
+        self.assertEqual(len(water.geoms[0].interiors), 0)
+
+    def test_empty_natural_coastline_raises_exception(self):
+        osm_map, bounds = self.parse_osm('coastline_empty_data.osm')
+
+        with self.assertRaisesRegex(
+            Exception,
+            'One or more OSM ways with the tag natural=coastline are required.'
+        ):
+            natural_coastline_to_multi_polygon(
+                osm_map,
+                bounds,
+                CoastlineOutputType.LAND
+            )
+
+    def test_incomplete_natural_coastline_start_raises_exception(self):
+        osm_map, bounds = self.parse_osm('coastline_incomplete_start_data.osm')
+
+        with self.assertRaisesRegex(
+            Exception,
+            'coastline way starts with a point that is inside the bounds.'
+        ):
+            natural_coastline_to_multi_polygon(
+                osm_map,
+                bounds,
+                CoastlineOutputType.LAND
+            )
+
+    def test_incomplete_natural_coastline_end_raises_exception(self):
+        osm_map, bounds = self.parse_osm('coastline_incomplete_end_data.osm')
+
+        with self.assertRaisesRegex(
+            Exception,
+            'coastline way ends with a point that is inside the bounds.'
+        ):
+            natural_coastline_to_multi_polygon(
+                osm_map,
+                bounds,
+                CoastlineOutputType.LAND
+            )
+
+    def test_nested_natural_coastline_raises_not_implemented_error(self):
+        osm_map, bounds = self.parse_osm('coastline_nested_data.osm')
+
+        with self.assertRaises(NotImplementedError):
+            natural_coastline_to_multi_polygon(
+                osm_map,
+                bounds,
+                CoastlineOutputType.LAND
+            )
+
+    def test_inverse_nested_natural_coastline_raises_not_implemented_error(
+        self
+    ):
+        osm_map, bounds = self.parse_osm('coastline_inverse_nested_data.osm')
+
+        with self.assertRaises(NotImplementedError):
+            natural_coastline_to_multi_polygon(
+                osm_map,
+                bounds,
+                CoastlineOutputType.LAND
+            )

--- a/tests/data/osm_shapely/test_natural_coastline.py
+++ b/tests/data/osm_shapely/test_natural_coastline.py
@@ -1,0 +1,35 @@
+import unittest
+from pathlib import Path
+
+from map_engraver.data.osm import Parser, Node
+from map_engraver.data.osm.filter import filter_elements
+from map_engraver.data.osm_shapely.natural_coastline import \
+    natural_coastline_to_multi_polygon, CoastlineOutputType
+
+
+class TestNaturalCoastline(unittest.TestCase):
+    def test_natural_coastline_conversion(self):
+        path = Path(__file__).parent.joinpath('coastline_data.osm')
+
+        osm_map = Parser.parse(path)
+
+        bbox_nodes = list(filter_elements(
+            osm_map,
+            lambda _, node: (
+                    'bbox' in node.tags
+            ),
+            filter_ways=False,
+            filter_relations=False
+        ).nodes.values())
+
+        assert len(bbox_nodes) == 2
+        min_node = bbox_nodes[0]
+        max_node = bbox_nodes[1]
+        if bbox_nodes[1].tags['bbox'] == 'min':
+            min_node = bbox_nodes[1]
+            max_node = bbox_nodes[0]
+
+        bounds = (min_node.lat, min_node.lon, max_node.lat, max_node.lon)
+        print(bounds)
+
+        natural_coastline_to_multi_polygon(osm_map, bounds, CoastlineOutputType.LAND)


### PR DESCRIPTION
In OpenStreetMap, way elements with the tag `natural=coastline` are a special case of element which behave like a multipolygon relation, but are actually not relations. They are specifically not relations to avoid clients having to download all relation members to edit. However, that does mean that the polygons are incomplete when downloaded, and it can therefore be difficult to render the land as a shape.

map-engraver will benefit from having a function that can read an OSM file and generate coastline data using incomplete coastline segments.


Below are examples of the output of `natural_coastline_to_multi_polygon(osm, bounds, output_type)`. The function can return either land or water shapes.

| Land | Water |
|---|----|
| <img width="612" alt="Screenshot 2022-10-30 at 00 28 10" src="https://user-images.githubusercontent.com/3501061/198856395-2797c0de-5a49-4be2-90f3-04151ebbf1d4.png"> | <img width="627" alt="Screenshot 2022-10-30 at 00 28 57" src="https://user-images.githubusercontent.com/3501061/198856401-70969ae0-3e2b-4da7-89b2-83744c114f6a.png"> |