### PR TITLE
Piece together non-congruent OSM relation multipolygons

### DIFF
--- a/map_engraver/data/osm_shapely/natural_coastline.py
+++ b/map_engraver/data/osm_shapely/natural_coastline.py
@@ -91,6 +91,7 @@ def natural_coastline_to_multi_polygon(
         way_all_nodes,
         way_start_nodes,
         way_end_nodes,
+        False
     )
 
     # Convert all complete_way_nodes to Polygons. Clockwise polygons are

--- a/map_engraver/data/osm_shapely/osm_to_shapely.py
+++ b/map_engraver/data/osm_shapely/osm_to_shapely.py
@@ -120,7 +120,8 @@ class OsmToShapely:
             outer_way_refs,
             outer_way_all_nodes,
             outer_way_start_nodes,
-            outer_way_end_nodes
+            outer_way_end_nodes,
+            True
         )
 
         # Fail completely if there are any instances of incomplete_way_refs
@@ -156,7 +157,8 @@ class OsmToShapely:
             inner_way_refs,
             inner_way_all_nodes,
             inner_way_start_node,
-            inner_way_end_node
+            inner_way_end_node,
+            True
         )
 
         if len(incomplete_ways_nodes) > 0:

--- a/map_engraver/data/osm_shapely/piece_together_ways.py
+++ b/map_engraver/data/osm_shapely/piece_together_ways.py
@@ -7,7 +7,8 @@ def piece_together_ways(
         way_refs: List[str],
         way_nodes: Dict[str, List[Node]],
         way_start_nodes: Dict[str, Node],
-        way_end_nodes: Dict[str, Node]
+        way_end_nodes: Dict[str, Node],
+        check_both_sides: bool
 ) -> Tuple[Dict[str, List[Node]], Dict[str, List[Node]]]:
     output_ways = dict()
     way_ref_index_1 = 0
@@ -42,17 +43,33 @@ def piece_together_ways(
 
             # print("ref2 " + str(way_ref_2))
 
+            ways_are_congruent = (
+                way_end_nodes[way_ref_1] == way_start_nodes[way_ref_2]
+            )
+            ways_are_opposing = (
+                way_end_nodes[way_ref_1] == way_end_nodes[way_ref_2]
+            )
+
             # if the end node of the current way is connected to the start
             # node of the other way
-            if way_end_nodes[way_ref_1] == way_start_nodes[way_ref_2]:
+            if (
+                ways_are_congruent or
+                (check_both_sides and ways_are_opposing)
+            ):
+                if ways_are_congruent:
+                    way_nodes_2 = way_nodes[way_ref_2][1:]
+                else:
+                    way_nodes_2 = reversed(way_nodes[way_ref_2][:-1])
                 # remove the first node of the other way to ensure we don't
                 # have redundant nodes and add it to the end of the current
                 # way
-                way_nodes_2 = way_nodes[way_ref_2][1:]
                 way_nodes[way_ref_1].extend(way_nodes_2)
 
                 # updated the linked list attributes
-                way_end_nodes[way_ref_1] = way_end_nodes[way_ref_2]
+                if ways_are_congruent:
+                    way_end_nodes[way_ref_1] = way_end_nodes[way_ref_2]
+                else:
+                    way_end_nodes[way_ref_1] = way_start_nodes[way_ref_2]
 
                 # Delete any mention of this way entirely!
                 del way_nodes[way_ref_2]

--- a/tests/data/osm_shapely/relation_same_direction_data.osm
+++ b/tests/data/osm_shapely/relation_same_direction_data.osm
@@ -1,0 +1,65 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osm version='0.6' generator='JOSM'>
+  <node id='-119400' action='modify' visible='true' lat='41.40584898473' lon='2.21960304022' />
+  <node id='-119401' action='modify' visible='true' lat='41.40285539667' lon='2.2154617095' />
+  <node id='-119403' action='modify' visible='true' lat='41.40023187009' lon='2.21378801107' />
+  <node id='-119404' action='modify' visible='true' lat='41.3992500323' lon='2.21228597403' />
+  <node id='-119405' action='modify' visible='true' lat='41.39651368477' lon='2.2100758338' />
+  <node id='-119406' action='modify' visible='true' lat='41.3960951744' lon='2.20951793432' />
+  <node id='-119407' action='modify' visible='true' lat='41.39641710569' lon='2.20913169622' />
+  <node id='-119408' action='modify' visible='true' lat='41.39432452379' lon='2.20621345282' />
+  <node id='-119410' action='modify' visible='true' lat='41.39182943425' lon='2.20441100836' />
+  <node id='-119412' action='modify' visible='true' lat='41.39047721669' lon='2.20138547659' />
+  <node id='-119413' action='modify' visible='true' lat='41.3893664455' lon='2.20039842367' />
+  <node id='-119414' action='modify' visible='true' lat='41.38883520039' lon='2.20117089987' />
+  <node id='-119415' action='modify' visible='true' lat='41.40538225158' lon='2.220075109' />
+  <node id='-119416' action='modify' visible='true' lat='41.40432806609' lon='2.2182297492' />
+  <node id='-119418' action='modify' visible='true' lat='41.40293587127' lon='2.21687791586' />
+  <node id='-119419' action='modify' visible='true' lat='41.40167240853' lon='2.21531150579' />
+  <node id='-119421' action='modify' visible='true' lat='41.40005481847' lon='2.21406696081' />
+  <node id='-119422' action='modify' visible='true' lat='41.39947537343' lon='2.21421716452' />
+  <node id='-119424' action='modify' visible='true' lat='41.39820379538' lon='2.21223232985' />
+  <node id='-119425' action='modify' visible='true' lat='41.39614346419' lon='2.21048352957' />
+  <node id='-119426' action='modify' visible='true' lat='41.39580543487' lon='2.2098397994' />
+  <node id='-119427' action='modify' visible='true' lat='41.39480743329' lon='2.20775840521' />
+  <node id='-119429' action='modify' visible='true' lat='41.39147528475' lon='2.20535514593' />
+  <node id='-119430' action='modify' visible='true' lat='41.39178114125' lon='2.20496890783' />
+  <node id='-119432' action='modify' visible='true' lat='41.39054965763' lon='2.20280168295' />
+  <way id='-106431' action='modify' visible='true'>
+    <nd ref='-119400' />
+    <nd ref='-119401' />
+    <nd ref='-119403' />
+    <nd ref='-119404' />
+    <nd ref='-119405' />
+    <nd ref='-119406' />
+    <nd ref='-119407' />
+    <nd ref='-119408' />
+    <nd ref='-119410' />
+    <nd ref='-119412' />
+    <nd ref='-119413' />
+    <nd ref='-119414' />
+  </way>
+  <way id='-106445' action='modify' visible='true'>
+    <nd ref='-119400' />
+    <nd ref='-119415' />
+    <nd ref='-119416' />
+    <nd ref='-119418' />
+    <nd ref='-119419' />
+    <nd ref='-119421' />
+    <nd ref='-119422' />
+    <nd ref='-119424' />
+    <nd ref='-119425' />
+    <nd ref='-119426' />
+    <nd ref='-119427' />
+    <nd ref='-119429' />
+    <nd ref='-119430' />
+    <nd ref='-119432' />
+    <nd ref='-119414' />
+  </way>
+  <relation id='-99959' action='modify' visible='true'>
+    <member type='way' ref='-106445' role='outer' />
+    <member type='way' ref='-106431' role='outer' />
+    <tag k='natural' v='beach' />
+    <tag k='type' v='multipolygon' />
+  </relation>
+</osm>

--- a/tests/data/osm_shapely/test_osm_to_shapely.py
+++ b/tests/data/osm_shapely/test_osm_to_shapely.py
@@ -196,6 +196,50 @@ class TestOsmToShapely(unittest.TestCase):
         )
         assert len(multi_polygons) == 2
 
+    def test_multipolygon_relation(self):
+        path = Path(__file__).parent.joinpath(
+            'relation_same_direction_data.osm'
+        )
+
+        osm_map = Parser.parse(path)
+        osm_to_shapely = OsmToShapely(osm_map)
+
+        # Node to Point
+        beach_relation = osm_map.get_relation('-99959')
+        beach_multi_polygon = osm_to_shapely.relation_to_multi_polygon(
+            beach_relation
+        )
+        self.assertEqual(len(beach_multi_polygon.geoms), 1)
+        self.assertEqual(
+            list(list(beach_multi_polygon.geoms)[0].exterior.coords),
+            [(41.40584898473, 2.21960304022),
+             (41.40285539667, 2.2154617095),
+             (41.40023187009, 2.21378801107),
+             (41.3992500323, 2.21228597403),
+             (41.39651368477, 2.2100758338),
+             (41.3960951744, 2.20951793432),
+             (41.39641710569, 2.20913169622),
+             (41.39432452379, 2.20621345282),
+             (41.39182943425, 2.20441100836),
+             (41.39047721669, 2.20138547659),
+             (41.3893664455, 2.20039842367),
+             (41.38883520039, 2.20117089987),
+             (41.39054965763, 2.20280168295),
+             (41.39178114125, 2.20496890783),
+             (41.39147528475, 2.20535514593),
+             (41.39480743329, 2.20775840521),
+             (41.39580543487, 2.2098397994),
+             (41.39614346419, 2.21048352957),
+             (41.39820379538, 2.21223232985),
+             (41.39947537343, 2.21421716452),
+             (41.40005481847, 2.21406696081),
+             (41.40167240853, 2.21531150579),
+             (41.40293587127, 2.21687791586),
+             (41.40432806609, 2.2182297492),
+             (41.40538225158, 2.220075109),
+             (41.40584898473, 2.21960304022)]
+        )
+
     def test_conversion_fails_for_invalid_types(self):
         path = Path(__file__).parent.joinpath('data.osm')
 


### PR DESCRIPTION
Apparently members of a multipolygon relation in OpenStreetMap can be ordered in a direction that oppose each other. In other words, two ways in a multipolygon don't necessarily have to be going in a clockwise or anti-clockwise direction.

<img width="593" alt="Screenshot 2022-10-30 at 01 00 00" src="https://user-images.githubusercontent.com/3501061/198858003-c216d2d5-d0e7-4e3b-b275-8dcc13d14ccb.png">

This PR improves `relation_to_multi_polygon()` so that multipolygons with such members can be processed correctly.