### PR TITLE
Redefine CanvasBbox as min/max positions, add comparison methods to canvas unit

### DIFF
--- a/map_engraver/canvas/canvas_bbox.py
+++ b/map_engraver/canvas/canvas_bbox.py
@@ -1,58 +1,118 @@
+from typing import Tuple
+
 from map_engraver.canvas.canvas_coordinate import CanvasCoordinate
 from map_engraver.canvas.canvas_unit import CanvasUnit
 
 
 class CanvasBbox:
-    pos: CanvasCoordinate
-    width: CanvasUnit
-    height: CanvasUnit
+    min_pos: CanvasCoordinate
+    max_pos: CanvasCoordinate
 
     def __init__(
             self,
-            pos: CanvasCoordinate,
-            width: CanvasUnit,
-            height: CanvasUnit
+            min_pos: CanvasCoordinate,
+            max_pos: CanvasCoordinate
     ):
-        self.pos = pos
-        self.width = width
-        self.height = height
+        self.min_pos = min_pos
+        self.max_pos = max_pos
+
+        if self.min_pos.x > self.max_pos.x:
+            raise Exception('min_pos.x cannot be greater than max_pos.x')
+        if self.min_pos.y > self.max_pos.y:
+            raise Exception('min_pos.y cannot be greater than max_pos.y')
+
+    @property
+    def width(self) -> CanvasUnit:
+        return self.max_pos.x - self.min_pos.x
+
+    @property
+    def height(self) -> CanvasUnit:
+        return self.max_pos.y - self.min_pos.y
+
+    @property
+    def bounds(self) -> Tuple[CanvasUnit, CanvasUnit, CanvasUnit, CanvasUnit]:
+        """Returns the bounding region as a tuple (minx, miny, maxx, maxy)"""
+        return (
+            self.min_pos.x,
+            self.min_pos.y,
+            self.max_pos.x,
+            self.max_pos.y
+        )
 
     @classmethod
-    def from_pt(cls, x: float, y: float, w: float, h: float) -> 'CanvasBbox':
+    def from_size(
+        cls,
+        x: CanvasUnit,
+        y: CanvasUnit,
+        w: CanvasUnit,
+        h: CanvasUnit
+    ) -> 'CanvasBbox':
+        return CanvasBbox(
+            CanvasCoordinate(x, y),
+            CanvasCoordinate(x + w, y + h)
+        )
+
+    @classmethod
+    def from_size_pt(
+        cls,
+        x: float,
+        y: float,
+        w: float,
+        h: float
+    ) -> 'CanvasBbox':
         return CanvasBbox(
             CanvasCoordinate.from_pt(x, y),
-            CanvasUnit.from_pt(w),
-            CanvasUnit.from_pt(h)
+            CanvasCoordinate.from_pt(x + w, y + h)
         )
 
     @classmethod
-    def from_px(cls, x: float, y: float, w: float, h: float) -> 'CanvasBbox':
+    def from_size_px(
+            cls,
+            x: float,
+            y: float,
+            w: float,
+            h: float
+    ) -> 'CanvasBbox':
         return CanvasBbox(
             CanvasCoordinate.from_px(x, y),
-            CanvasUnit.from_px(w),
-            CanvasUnit.from_px(h)
+            CanvasCoordinate.from_px(x + w, y + h)
         )
 
     @classmethod
-    def from_in(cls, x: float, y: float, w: float, h: float) -> 'CanvasBbox':
+    def from_size_in(
+            cls,
+            x: float,
+            y: float,
+            w: float,
+            h: float
+    ) -> 'CanvasBbox':
         return CanvasBbox(
             CanvasCoordinate.from_in(x, y),
-            CanvasUnit.from_in(w),
-            CanvasUnit.from_in(h)
+            CanvasCoordinate.from_in(x + w, y + h)
         )
 
     @classmethod
-    def from_cm(cls, x: float, y: float, w: float, h: float) -> 'CanvasBbox':
+    def from_size_cm(
+            cls,
+            x: float,
+            y: float,
+            w: float,
+            h: float
+    ) -> 'CanvasBbox':
         return CanvasBbox(
             CanvasCoordinate.from_cm(x, y),
-            CanvasUnit.from_cm(w),
-            CanvasUnit.from_cm(h)
+            CanvasCoordinate.from_cm(x + w, y + h)
         )
 
     @classmethod
-    def from_mm(cls, x: float, y: float, w: float, h: float) -> 'CanvasBbox':
+    def from_size_mm(
+            cls,
+            x: float,
+            y: float,
+            w: float,
+            h: float
+    ) -> 'CanvasBbox':
         return CanvasBbox(
             CanvasCoordinate.from_mm(x, y),
-            CanvasUnit.from_mm(w),
-            CanvasUnit.from_mm(h)
+            CanvasCoordinate.from_mm(x + w, y + h)
         )

--- a/map_engraver/canvas/canvas_unit.py
+++ b/map_engraver/canvas/canvas_unit.py
@@ -84,6 +84,30 @@ class CanvasUnit:
         else:
             return False
 
+    def __lt__(self, other):
+        if isinstance(other, CanvasUnit):
+            return self.pt.__lt__(other.pt)
+        else:
+            raise NotImplementedError()
+
+    def __gt__(self, other):
+        if isinstance(other, CanvasUnit):
+            return self.pt.__gt__(other.pt)
+        else:
+            raise NotImplementedError()
+
+    def __le__(self, other):
+        if isinstance(other, CanvasUnit):
+            return self.pt.__le__(other.pt)
+        else:
+            raise NotImplementedError()
+
+    def __ge__(self, other):
+        if isinstance(other, CanvasUnit):
+            return self.pt.__ge__(other.pt)
+        else:
+            raise NotImplementedError()
+
     def __add__(self, other):
         if isinstance(other, CanvasUnit):
             return CanvasUnit(self.pt + other.pt)

--- a/map_engraver/data/canvas_geometry/rect.py
+++ b/map_engraver/data/canvas_geometry/rect.py
@@ -12,10 +12,10 @@ def rect(bbox: CanvasBbox) -> Polygon:
     if bbox.height.pt <= 0:
         raise Exception('height of bbox cannot be 0 or less.')
     return Polygon([
-        bbox.pos.pt,
-        CanvasCoordinate(bbox.pos.x + bbox.width, bbox.pos.y).pt,
-        CanvasCoordinate(bbox.pos.x + bbox.width, bbox.pos.y + bbox.height).pt,
-        CanvasCoordinate(bbox.pos.x, bbox.pos.y + bbox.height).pt
+        bbox.min_pos.pt,
+        CanvasCoordinate(bbox.max_pos.x, bbox.min_pos.y).pt,
+        bbox.max_pos.pt,
+        CanvasCoordinate(bbox.min_pos.x, bbox.max_pos.y).pt
     ])
 
 
@@ -30,10 +30,10 @@ def rounded_rect(
     if radius.pt < 0:
         raise Exception('radius cannot be 0 or less.')
 
-    ul = bbox.pos
-    ur = CanvasCoordinate(bbox.pos.x + bbox.width, bbox.pos.y)
-    br = CanvasCoordinate(bbox.pos.x + bbox.width, bbox.pos.y + bbox.height)
-    bl = CanvasCoordinate(bbox.pos.x, bbox.pos.y + bbox.height)
+    ul = bbox.min_pos
+    ur = CanvasCoordinate(bbox.max_pos.x, bbox.min_pos.y)
+    br = bbox.max_pos
+    bl = CanvasCoordinate(bbox.min_pos.x, bbox.max_pos.y)
 
     max_radius_pt = min(radius.pt, bbox.width.pt / 2, bbox.height.pt / 2)
 

--- a/map_engraver/data/pango/layout.py
+++ b/map_engraver/data/pango/layout.py
@@ -43,11 +43,7 @@ class Layout:
         y += self._position.y
         width = CanvasUnit.from_pt(pangocffi.units_to_double(extent.width))
         height = CanvasUnit.from_pt(pangocffi.units_to_double(extent.height))
-        return CanvasBbox(
-            CanvasCoordinate(x, y),
-            width,
-            height
-        )
+        return CanvasBbox.from_size(x, y, width, height)
 
     @property
     def height(self) -> Optional[CanvasUnit]:

--- a/tests/canvas/test_canvas_bbox.py
+++ b/tests/canvas/test_canvas_bbox.py
@@ -7,30 +7,66 @@ from map_engraver.canvas.canvas_unit import CanvasUnit as Cu
 
 class TestCanvasBbox(unittest.TestCase):
     def test_init(self):
-        bbox = CanvasBbox(Cc.from_in(1, 2), Cu.from_in(3), Cu.from_in(4))
-        assert bbox.pos == Cc.from_in(1, 2)
-        assert bbox.width == Cu.from_in(3)
-        assert bbox.height == Cu.from_in(4)
+        bbox = CanvasBbox(Cc.from_in(1, 2), Cc.from_in(4, 6))
+        assert bbox.min_pos == Cc.from_in(1, 2)
+        assert bbox.max_pos == Cc.from_in(4, 6)
+
+    def test_invalid_init(self):
+        with self.assertRaises(Exception):
+            CanvasBbox(Cc.from_in(4, 2), Cc.from_in(1, 6))
+        with self.assertRaises(Exception):
+            CanvasBbox(Cc.from_in(1, 6), Cc.from_in(4, 2))
 
     def test_identity(self):
-        assert CanvasBbox.from_pt(1, 2, 3, 4).pos.pt == (1, 2)
-        assert CanvasBbox.from_pt(1, 2, 3, 4).width.pt == 3
-        assert CanvasBbox.from_pt(1, 2, 3, 4).height.pt == 4
+        bbox = CanvasBbox.from_size(
+            Cu.from_pt(1), Cu.from_pt(2), Cu.from_pt(3), Cu.from_pt(4)
+        )
+        assert bbox.min_pos.pt == (1, 2)
+        assert bbox.max_pos.pt == (4, 6)
 
-        assert CanvasBbox.from_px(1, 2, 3, 4).pos.px == (1, 2)
-        assert CanvasBbox.from_px(1, 2, 3, 4).width.px == 3
-        assert CanvasBbox.from_px(1, 2, 3, 4).height.px == 4
+        bbox = CanvasBbox.from_size_pt(1, 2, 3, 4)
+        assert bbox.min_pos.pt == (1, 2)
+        assert bbox.max_pos.pt == (4, 6)
 
-        assert CanvasBbox.from_in(1, 2, 3, 4).pos.inches == (1, 2)
-        assert CanvasBbox.from_in(1, 2, 3, 4).width.inches == 3
-        assert CanvasBbox.from_in(1, 2, 3, 4).height.inches == 4
+        bbox = CanvasBbox.from_size_px(1, 2, 3, 4)
+        assert bbox.min_pos.px == (1, 2)
+        assert bbox.max_pos.px == (4, 6)
 
-        assert CanvasBbox.from_mm(1, 2, 3, 4).pos.mm == (1, 2)
+        bbox = CanvasBbox.from_size_in(1, 2, 3, 4)
+        assert bbox.min_pos.inches == (1, 2)
+        assert bbox.max_pos.inches == (4, 6)
+
+        bbox = CanvasBbox.from_size_mm(1, 2, 3, 4)
         # Round to solve floating point issues
-        assert round(CanvasBbox.from_mm(1, 2, 3, 4).width.mm) == 3
-        assert CanvasBbox.from_mm(1, 2, 3, 4).height.mm == 4
+        assert round(bbox.min_pos.x.mm) == 1
+        assert round(bbox.min_pos.y.mm) == 2
+        assert round(bbox.max_pos.x.mm) == 4
+        assert round(bbox.max_pos.y.mm) == 6
 
-        assert CanvasBbox.from_cm(1, 2, 3, 4).pos.cm == (1, 2)
+        bbox = CanvasBbox.from_size_cm(1, 2, 3, 4)
         # Round to solve floating point issues
-        assert round(CanvasBbox.from_cm(1, 2, 3, 4).width.cm) == 3
-        assert CanvasBbox.from_cm(1, 2, 3, 4).height.cm == 4
+        assert round(bbox.min_pos.x.cm) == 1
+        assert round(bbox.min_pos.y.cm) == 2
+        assert round(bbox.max_pos.x.cm) == 4
+        assert round(bbox.max_pos.y.cm) == 6
+
+    def test_width_and_height(self):
+        bbox = CanvasBbox.from_size(
+            Cu.from_pt(1), Cu.from_pt(2), Cu.from_pt(3), Cu.from_pt(4)
+        )
+        assert bbox.width.pt == 3
+        assert bbox.height.pt == 4
+
+    def test_bounds(self):
+        assert CanvasBbox.from_size_pt(1, 2, 3, 4).bounds == (
+            Cu.from_pt(1),
+            Cu.from_pt(2),
+            Cu.from_pt(4),
+            Cu.from_pt(6)
+        )
+        assert CanvasBbox.from_size_in(1, 2, 3, 4).bounds == (
+            Cu.from_in(1),
+            Cu.from_in(2),
+            Cu.from_in(4),
+            Cu.from_in(6)
+        )

--- a/tests/canvas/test_canvas_unit.py
+++ b/tests/canvas/test_canvas_unit.py
@@ -40,6 +40,29 @@ class TestCanvasUnit(unittest.TestCase):
         assert CanvasUnit.from_cm(2) == CanvasUnit.from_cm(2)
         assert CanvasUnit.from_cm(2) != 2
 
+    # noinspection PyStatementEffect
+    def test_gt_ge_lt_le(self):
+        assert not CanvasUnit.from_cm(3) > CanvasUnit.from_cm(5)
+        assert not CanvasUnit.from_cm(5) > CanvasUnit.from_cm(5)
+        assert CanvasUnit.from_cm(7) > CanvasUnit.from_cm(5)
+        assert not CanvasUnit.from_cm(3) >= CanvasUnit.from_cm(5)
+        assert CanvasUnit.from_cm(5) >= CanvasUnit.from_cm(5)
+        assert CanvasUnit.from_cm(7) >= CanvasUnit.from_cm(5)
+        assert CanvasUnit.from_cm(3) < CanvasUnit.from_cm(5)
+        assert not CanvasUnit.from_cm(5) < CanvasUnit.from_cm(5)
+        assert not CanvasUnit.from_cm(7) < CanvasUnit.from_cm(5)
+        assert CanvasUnit.from_cm(3) <= CanvasUnit.from_cm(5)
+        assert CanvasUnit.from_cm(5) <= CanvasUnit.from_cm(5)
+        assert not CanvasUnit.from_cm(7) <= CanvasUnit.from_cm(5)
+        with self.assertRaises(NotImplementedError):
+            CanvasUnit.from_cm(1) > 1
+        with self.assertRaises(NotImplementedError):
+            CanvasUnit.from_cm(1) >= 1
+        with self.assertRaises(NotImplementedError):
+            CanvasUnit.from_cm(1) < 1
+        with self.assertRaises(NotImplementedError):
+            CanvasUnit.from_cm(1) <= 1
+
     def test_add(self):
         assert CanvasUnit.from_cm(2) + CanvasUnit.from_cm(3) == \
                CanvasUnit.from_cm(5)

--- a/tests/data/canvas_geometry/test_rect.py
+++ b/tests/data/canvas_geometry/test_rect.py
@@ -12,32 +12,32 @@ class TestRect(unittest.TestCase):
         # rect()
         with self.assertRaises(Exception):
             rect(
-                CanvasBbox.from_px(10, 20, 0, 40),
+                CanvasBbox.from_size_px(10, 20, 0, 40),
             )
         with self.assertRaises(Exception):
             rect(
-                CanvasBbox.from_px(10, 20, 30, 0),
+                CanvasBbox.from_size_px(10, 20, 30, 0),
             )
         # rounded rect()
         with self.assertRaises(Exception):
             rounded_rect(
-                CanvasBbox.from_px(10, 20, 0, 40),
+                CanvasBbox.from_size_px(10, 20, 0, 40),
                 CanvasUnit.from_px(10)
             )
         with self.assertRaises(Exception):
             rounded_rect(
-                CanvasBbox.from_px(10, 20, 30, 0),
+                CanvasBbox.from_size_px(10, 20, 30, 0),
                 CanvasUnit.from_px(10)
             )
         with self.assertRaises(Exception):
             rounded_rect(
-                CanvasBbox.from_px(10, 20, 30, 40),
+                CanvasBbox.from_size_px(10, 20, 30, 40),
                 CanvasUnit.from_px(-10)
             )
 
     def test_rect_is_returned(self):
         rr = rect(
-            CanvasBbox.from_pt(10, 20, 30, 40),
+            CanvasBbox.from_size_pt(10, 20, 30, 40),
         )
         assert rr.bounds == (10, 20, 40, 60)
         assert rr.touches(Point(*CanvasCoordinate.from_pt(10, 20).pt))
@@ -45,7 +45,7 @@ class TestRect(unittest.TestCase):
 
     def test_rounded_rect_without_radius_is_returned(self):
         rr = rounded_rect(
-            CanvasBbox.from_pt(10, 20, 30, 40),
+            CanvasBbox.from_size_pt(10, 20, 30, 40),
             CanvasUnit.from_pt(0)
         )
         assert rr.bounds == (10, 20, 40, 60)
@@ -54,7 +54,7 @@ class TestRect(unittest.TestCase):
 
     def test_rounded_rect_with_radius_is_returned(self):
         rr = rounded_rect(
-            CanvasBbox.from_pt(10, 20, 30, 40),
+            CanvasBbox.from_size_pt(10, 20, 30, 40),
             CanvasUnit.from_pt(5)
         )
         assert rr.bounds == (10, 20, 40, 60)

--- a/tests/data/geo_canvas_ops/test_geo_canvas_mask.py
+++ b/tests/data/geo_canvas_ops/test_geo_canvas_mask.py
@@ -15,7 +15,7 @@ from map_engraver.data.geo_canvas_ops.geo_canvas_transformers_builder import \
 
 class TestMasks(unittest.TestCase):
     def test_canvas_mask(self):
-        canvas_size = rect(CanvasBbox.from_pt(-20, 50, 170, 100))
+        canvas_size = rect(CanvasBbox.from_size_pt(-20, 50, 170, 100))
         builder = GeoCanvasTransformersBuilder()
         builder.set_scale_and_origin_from_coordinates_and_crs(
             CRS.from_proj4('+proj=ortho +lon_0=0 +lat_0=0'),
@@ -33,7 +33,7 @@ class TestMasks(unittest.TestCase):
         self.assertAlmostEqual(mask_bounds[3], 150, 4)
 
     def test_canvas_wgs84_mask(self):
-        canvas_size = rect(CanvasBbox.from_pt(-20, 50, 170, 100))
+        canvas_size = rect(CanvasBbox.from_size_pt(-20, 50, 170, 100))
         builder = GeoCanvasTransformersBuilder()
         builder.set_scale_and_origin_from_coordinates_and_crs(
             CRS.from_proj4('+proj=ortho +lon_0=0 +lat_0=0'),
@@ -51,7 +51,7 @@ class TestMasks(unittest.TestCase):
         self.assertAlmostEqual(mask_bounds[3], 27.2961, 4)
 
     def test_canvas_crs_mask(self):
-        canvas_size = rect(CanvasBbox.from_pt(-20, 50, 170, 100))
+        canvas_size = rect(CanvasBbox.from_size_pt(-20, 50, 170, 100))
         builder = GeoCanvasTransformersBuilder()
         builder.set_scale_and_origin_from_coordinates_and_crs(
             CRS.from_proj4('+proj=ortho +lon_0=0 +lat_0=0'),
@@ -69,7 +69,7 @@ class TestMasks(unittest.TestCase):
         self.assertAlmostEqual(mask_bounds[3], 2657152.324517375, 4)
 
     def test_functions_for_crs_with_unknown_mask(self):
-        canvas_size = rect(CanvasBbox.from_pt(-20, 50, 170, 100))
+        canvas_size = rect(CanvasBbox.from_size_pt(-20, 50, 170, 100))
         builder = GeoCanvasTransformersBuilder()
         builder.set_scale_and_origin_from_coordinates_and_crs(
             CRS.from_proj4('+proj=nzmg +lat_0=-41 +lon_0=173 +x_0=0 +y_0=0'),

--- a/tests/data/geotiff/test_canvas_transform.py
+++ b/tests/data/geotiff/test_canvas_transform.py
@@ -40,8 +40,7 @@ class TestCanvasTransform(unittest.TestCase):
         canvas_height = CanvasUnit.from_px(500)
         canvas_mask = rect(CanvasBbox(
             CanvasCoordinate.origin(),
-            canvas_width,
-            canvas_height
+            CanvasCoordinate(canvas_width, canvas_height)
         ))
 
         wgs84_crs = CRS.from_epsg(4326)
@@ -74,8 +73,7 @@ class TestCanvasTransform(unittest.TestCase):
         canvas_height = CanvasUnit.from_px(500)
         canvas_mask = rect(CanvasBbox(
             CanvasCoordinate.origin(),
-            canvas_width,
-            canvas_height
+            CanvasCoordinate(canvas_width, canvas_height)
         ))
 
         crs = CRS.from_proj4('+proj=utm +zone=30')
@@ -131,8 +129,7 @@ class TestCanvasTransform(unittest.TestCase):
         canvas_height = CanvasUnit.from_px(170)
         canvas_mask = rect(CanvasBbox(
             CanvasCoordinate.origin(),
-            canvas_width,
-            canvas_height
+            CanvasCoordinate(canvas_width, canvas_height)
         ))
         canvas_builder = CanvasBuilder()
         canvas_builder.set_path(canvas_file)
@@ -185,8 +182,10 @@ class TestCanvasTransform(unittest.TestCase):
         polygon_drawer.geoms = [rect(
             CanvasBbox(
                 CanvasCoordinate.origin(),
-                CanvasUnit.from_px(output_bitmap.width),
-                CanvasUnit.from_px(output_bitmap.height)
+                CanvasCoordinate.from_px(
+                    output_bitmap.width,
+                    output_bitmap.height
+                )
             )
         )]
         polygon_drawer.draw(canvas)

--- a/tests/data/pango/test_layout.py
+++ b/tests/data/pango/test_layout.py
@@ -57,7 +57,7 @@ class TestLayout(unittest.TestCase):
         assert layout.alignment == Alignment.RIGHT
 
         extents = layout.logical_extents
-        assert extents.pos.x.pt == 10
-        assert extents.pos.y.pt == 5
+        assert extents.min_pos.x.pt == 10
+        assert extents.min_pos.y.pt == 5
         assert extents.width.pt > 1
         assert extents.height.pt > 1

--- a/tests/e2e/image_rendering/test_geotiff_display.py
+++ b/tests/e2e/image_rendering/test_geotiff_display.py
@@ -108,7 +108,7 @@ class TestGeotiffDisplay(unittest.TestCase):
         canvas.close()
 
     def test_geotiff_display(self):
-        canvas_box = CanvasBbox.from_px(0, 0, 150, 200)
+        canvas_box = CanvasBbox.from_size_px(0, 0, 150, 200)
         crs = CRS.from_proj4('+proj=utm +zone=30')
         wgs84_crs = CRS.from_epsg(4326)
         builder = GeoCanvasTransformersBuilder()

--- a/tests/e2e/projection_rendering/test_geo_canvas_rendering.py
+++ b/tests/e2e/projection_rendering/test_geo_canvas_rendering.py
@@ -38,19 +38,19 @@ class TestGeoCanvasRendering(unittest.TestCase):
 
     crs_width = 400
     crs_height = 400
-    crs_bbox = CanvasBbox.from_px(
+    crs_bbox = CanvasBbox.from_size_px(
         canvas_margin, canvas_margin,
         crs_width, crs_height
     )
 
     wgs84_width = 360
     wgs84_height = 180
-    wgs84_bbox = CanvasBbox.from_px(
+    wgs84_bbox = CanvasBbox.from_size_px(
         canvas_margin * 2 + crs_width, canvas_margin,
         wgs84_width, wgs84_height
     )
 
-    whole_canvas_bbox = CanvasBbox.from_px(
+    whole_canvas_bbox = CanvasBbox.from_size_px(
         0, 0,
         canvas_margin * 3 + crs_width + wgs84_width,
         crs_height + canvas_margin * 2
@@ -185,7 +185,7 @@ class TestGeoCanvasRendering(unittest.TestCase):
 
         wgs84_transformer = GeoCanvasTransformersBuilder()
         wgs84_transformer.set_crs(CRS.from_epsg(4326))
-        wgs84_transformer.set_origin_for_canvas(self.wgs84_bbox.pos)
+        wgs84_transformer.set_origin_for_canvas(self.wgs84_bbox.min_pos)
         wgs84_transformer.set_origin_for_geo(
             GeoCoordinate(90, -180, CRS.from_epsg(4326))
         )
@@ -231,12 +231,12 @@ class TestGeoCanvasRendering(unittest.TestCase):
                 'geo_a': GeoCoordinate(0, -70, CRS.from_epsg(4326)),
                 'geo_b': GeoCoordinate(0, 70, CRS.from_epsg(4326)),
                 'canvas_a': CanvasCoordinate(
-                    self.crs_bbox.pos.x,
-                    self.crs_bbox.pos.y + self.crs_bbox.height / 2
+                    self.crs_bbox.min_pos.x,
+                    self.crs_bbox.min_pos.y + self.crs_bbox.height / 2
                 ),
                 'canvas_b': CanvasCoordinate(
-                    self.crs_bbox.pos.x + self.crs_bbox.width,
-                    self.crs_bbox.pos.y + self.crs_bbox.height / 2
+                    self.crs_bbox.min_pos.x + self.crs_bbox.width,
+                    self.crs_bbox.min_pos.y + self.crs_bbox.height / 2
                 )
             },
             {
@@ -244,12 +244,12 @@ class TestGeoCanvasRendering(unittest.TestCase):
                 'geo_a': GeoCoordinate(0, 150, CRS.from_epsg(4326)),
                 'geo_b': GeoCoordinate(0, -150, CRS.from_epsg(4326)),
                 'canvas_a': CanvasCoordinate(
-                    self.crs_bbox.pos.x,
-                    self.crs_bbox.pos.y + self.crs_bbox.height / 2
+                    self.crs_bbox.min_pos.x,
+                    self.crs_bbox.min_pos.y + self.crs_bbox.height / 2
                 ),
                 'canvas_b': CanvasCoordinate(
-                    self.crs_bbox.pos.x + self.crs_bbox.width,
-                    self.crs_bbox.pos.y + self.crs_bbox.height / 2
+                    self.crs_bbox.min_pos.x + self.crs_bbox.width,
+                    self.crs_bbox.min_pos.y + self.crs_bbox.height / 2
                 )
             },
             {
@@ -257,12 +257,12 @@ class TestGeoCanvasRendering(unittest.TestCase):
                 'geo_a': GeoCoordinate(40, -40, CRS.from_epsg(4326)),
                 'geo_b': GeoCoordinate(40, 20, CRS.from_epsg(4326)),
                 'canvas_a': CanvasCoordinate(
-                    self.crs_bbox.pos.x,
-                    self.crs_bbox.pos.y + self.crs_bbox.height / 2
+                    self.crs_bbox.min_pos.x,
+                    self.crs_bbox.min_pos.y + self.crs_bbox.height / 2
                 ),
                 'canvas_b': CanvasCoordinate(
-                    self.crs_bbox.pos.x + self.crs_bbox.width,
-                    self.crs_bbox.pos.y + self.crs_bbox.height / 2
+                    self.crs_bbox.min_pos.x + self.crs_bbox.width,
+                    self.crs_bbox.min_pos.y + self.crs_bbox.height / 2
                 )
             },
             {
@@ -270,12 +270,12 @@ class TestGeoCanvasRendering(unittest.TestCase):
                 'geo_a': GeoCoordinate(10, -180, CRS.from_epsg(4326)),
                 'geo_b': GeoCoordinate(10, 0, CRS.from_epsg(4326)),
                 'canvas_a': CanvasCoordinate(
-                    self.crs_bbox.pos.x,
-                    self.crs_bbox.pos.y + self.crs_bbox.height / 2
+                    self.crs_bbox.min_pos.x,
+                    self.crs_bbox.min_pos.y + self.crs_bbox.height / 2
                 ),
                 'canvas_b': CanvasCoordinate(
-                    self.crs_bbox.pos.x + self.crs_bbox.width,
-                    self.crs_bbox.pos.y + self.crs_bbox.height / 2
+                    self.crs_bbox.min_pos.x + self.crs_bbox.width,
+                    self.crs_bbox.min_pos.y + self.crs_bbox.height / 2
                 )
             },
             {
@@ -283,12 +283,12 @@ class TestGeoCanvasRendering(unittest.TestCase):
                 'geo_a': GeoCoordinate(-10, -180, CRS.from_epsg(4326)),
                 'geo_b': GeoCoordinate(-10, 0, CRS.from_epsg(4326)),
                 'canvas_a': CanvasCoordinate(
-                    self.crs_bbox.pos.x,
-                    self.crs_bbox.pos.y + self.crs_bbox.height / 2
+                    self.crs_bbox.min_pos.x,
+                    self.crs_bbox.min_pos.y + self.crs_bbox.height / 2
                 ),
                 'canvas_b': CanvasCoordinate(
-                    self.crs_bbox.pos.x + self.crs_bbox.width,
-                    self.crs_bbox.pos.y + self.crs_bbox.height / 2
+                    self.crs_bbox.min_pos.x + self.crs_bbox.width,
+                    self.crs_bbox.min_pos.y + self.crs_bbox.height / 2
                 )
             },
             {
@@ -296,12 +296,12 @@ class TestGeoCanvasRendering(unittest.TestCase):
                 'geo_a': GeoCoordinate(0, -140, CRS.from_epsg(4326)),
                 'geo_b': GeoCoordinate(0, 160, CRS.from_epsg(4326)),
                 'canvas_a': CanvasCoordinate(
-                    self.crs_bbox.pos.x,
-                    self.crs_bbox.pos.y + self.crs_bbox.height / 2
+                    self.crs_bbox.min_pos.x,
+                    self.crs_bbox.min_pos.y + self.crs_bbox.height / 2
                 ),
                 'canvas_b': CanvasCoordinate(
-                    self.crs_bbox.pos.x + self.crs_bbox.width,
-                    self.crs_bbox.pos.y + self.crs_bbox.height / 2
+                    self.crs_bbox.min_pos.x + self.crs_bbox.width,
+                    self.crs_bbox.min_pos.y + self.crs_bbox.height / 2
                 )
             },
             {
@@ -309,12 +309,12 @@ class TestGeoCanvasRendering(unittest.TestCase):
                 'geo_a': GeoCoordinate(45, -10, CRS.from_epsg(4326)),
                 'geo_b': GeoCoordinate(45, 56, CRS.from_epsg(4326)),
                 'canvas_a': CanvasCoordinate(
-                    self.crs_bbox.pos.x,
-                    self.crs_bbox.pos.y + self.crs_bbox.height / 2
+                    self.crs_bbox.min_pos.x,
+                    self.crs_bbox.min_pos.y + self.crs_bbox.height / 2
                 ),
                 'canvas_b': CanvasCoordinate(
-                    self.crs_bbox.pos.x + self.crs_bbox.width,
-                    self.crs_bbox.pos.y + self.crs_bbox.height / 2
+                    self.crs_bbox.min_pos.x + self.crs_bbox.width,
+                    self.crs_bbox.min_pos.y + self.crs_bbox.height / 2
                 )
             },
             {
@@ -322,12 +322,12 @@ class TestGeoCanvasRendering(unittest.TestCase):
                 'geo_a': GeoCoordinate(45, -10, CRS.from_epsg(4326)),
                 'geo_b': GeoCoordinate(45, 56, CRS.from_epsg(4326)),
                 'canvas_a': CanvasCoordinate(
-                    self.crs_bbox.pos.x,
-                    self.crs_bbox.pos.y + self.crs_bbox.height / 2
+                    self.crs_bbox.min_pos.x,
+                    self.crs_bbox.min_pos.y + self.crs_bbox.height / 2
                 ),
                 'canvas_b': CanvasCoordinate(
-                    self.crs_bbox.pos.x + self.crs_bbox.width,
-                    self.crs_bbox.pos.y + self.crs_bbox.height / 2
+                    self.crs_bbox.min_pos.x + self.crs_bbox.width,
+                    self.crs_bbox.min_pos.y + self.crs_bbox.height / 2
                 )
             },
             {
@@ -335,12 +335,12 @@ class TestGeoCanvasRendering(unittest.TestCase):
                 'geo_a': GeoCoordinate(55, -15, CRS.from_epsg(4326)),
                 'geo_b': GeoCoordinate(55, 6, CRS.from_epsg(4326)),
                 'canvas_a': CanvasCoordinate(
-                    self.crs_bbox.pos.x,
-                    self.crs_bbox.pos.y + self.crs_bbox.height / 2
+                    self.crs_bbox.min_pos.x,
+                    self.crs_bbox.min_pos.y + self.crs_bbox.height / 2
                 ),
                 'canvas_b': CanvasCoordinate(
-                    self.crs_bbox.pos.x + self.crs_bbox.width,
-                    self.crs_bbox.pos.y + self.crs_bbox.height / 2
+                    self.crs_bbox.min_pos.x + self.crs_bbox.width,
+                    self.crs_bbox.min_pos.y + self.crs_bbox.height / 2
                 )
             },
             {
@@ -348,12 +348,12 @@ class TestGeoCanvasRendering(unittest.TestCase):
                 'geo_a': GeoCoordinate(45, -10, CRS.from_epsg(4326)),
                 'geo_b': GeoCoordinate(45, 56, CRS.from_epsg(4326)),
                 'canvas_a': CanvasCoordinate(
-                    self.crs_bbox.pos.x,
-                    self.crs_bbox.pos.y + self.crs_bbox.height / 2
+                    self.crs_bbox.min_pos.x,
+                    self.crs_bbox.min_pos.y + self.crs_bbox.height / 2
                 ),
                 'canvas_b': CanvasCoordinate(
-                    self.crs_bbox.pos.x + self.crs_bbox.width,
-                    self.crs_bbox.pos.y + self.crs_bbox.height / 2
+                    self.crs_bbox.min_pos.x + self.crs_bbox.width,
+                    self.crs_bbox.min_pos.y + self.crs_bbox.height / 2
                 )
             },
             {
@@ -361,12 +361,12 @@ class TestGeoCanvasRendering(unittest.TestCase):
                 'geo_a': GeoCoordinate(9, -85, CRS.from_epsg(4326)),
                 'geo_b': GeoCoordinate(9, -75, CRS.from_epsg(4326)),
                 'canvas_a': CanvasCoordinate(
-                    self.crs_bbox.pos.x,
-                    self.crs_bbox.pos.y + self.crs_bbox.height / 2
+                    self.crs_bbox.min_pos.x,
+                    self.crs_bbox.min_pos.y + self.crs_bbox.height / 2
                 ),
                 'canvas_b': CanvasCoordinate(
-                    self.crs_bbox.pos.x + self.crs_bbox.width,
-                    self.crs_bbox.pos.y + self.crs_bbox.height / 2
+                    self.crs_bbox.min_pos.x + self.crs_bbox.width,
+                    self.crs_bbox.min_pos.y + self.crs_bbox.height / 2
                 )
             },
         ]


### PR DESCRIPTION
CanvasBbox is now defined as a min_pos and a max_pos. This confirms more to the expectations of what a "Boundary Box" is.

`bounds`, `width`, `height` have been added for convenience. class methods like `from_[unit]()` have been renamed to `from_size_[unit]`.

`<`, `<=`, `>`, `>=` methods have been added to CanvasUnit as well to make it easier to compare measurements.